### PR TITLE
Add ready time and message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .idea
 .settings
 .phpunit.result.cache
+translationfiles/*/postmag.mo
 TODO.md
 
 js

--- a/css/settingsAdmin.css
+++ b/css/settingsAdmin.css
@@ -1,6 +1,7 @@
 #postmagDomain,
 #postmagUserAliasIdLen,
-#postmagAliasIdLen
+#postmagAliasIdLen,
+#postmagReadyTime
 {
 	width: 300px;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -20,6 +20,14 @@
 	float: right;
 }
 
+.postmag-ready {
+	color: green;
+}
+
+.postmag-notReady {
+	color: orange;
+}
+
 #postmagAliasFormAliasName,
 #postmagAliasFormSendTo,
 #postmagAliasFormComment

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -42,6 +42,7 @@ OC.L10N.register(
     "Enabled" : "Aktiviert",
     "Created" : "Erstellt",
     "Last Modified" : "Zuletzt geändert",
+    "Ready" : "Bereit",
     "Alias name" : "Alias-Name",
     "Send to address" : "Ziel-Adresse",
     "Comment" : "Notizen",
@@ -54,7 +55,9 @@ OC.L10N.register(
     "No" : "Nein",
     "New alias" : "Neuer Alias",
     "Now" : "Jetzt",
+    "_%n second after creation_::_%n seconds after creation_" : ["%n Sekunde nach Erstellung","%n Sekunden nach Erstellung"],
     "Create" : "Anlegen",
+    "_In %n second_::_In %n seconds_" : ["In %n Sekunde","In %n Sekunden"],
     "All aliases" : "Alle Aliases",
     "Disabled" : "Deaktiviert",
     "Loading..." : "Lade...",
@@ -62,6 +65,7 @@ OC.L10N.register(
     "Set your target mail domain and alias id lengths." : "Konfiguriere deine Ziel-Domäne und wähle die Längen der Alias IDs.",
     "Target mail domain" : "Ziel-Mail-Domäne",
     "Length of user alias ids (only for new users)" : "Länge der User Alias IDs (nur bei neuen Benutzern)",
-    "Length of alias ids (only for new aliases)" : "Länge der Alias IDs (nur bei neuen Aliases)"
+    "Length of alias ids (only for new aliases)" : "Länge der Alias IDs (nur bei neuen Aliases)",
+    "Time until alias changes are valid (ready time in seconds)" : "Zeit bis Änderungen an Aliases gültig sind (in Sekunden)"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -40,6 +40,7 @@
     "Enabled" : "Aktiviert",
     "Created" : "Erstellt",
     "Last Modified" : "Zuletzt geändert",
+    "Ready" : "Bereit",
     "Alias name" : "Alias-Name",
     "Send to address" : "Ziel-Adresse",
     "Comment" : "Notizen",
@@ -52,7 +53,9 @@
     "No" : "Nein",
     "New alias" : "Neuer Alias",
     "Now" : "Jetzt",
+    "_%n second after creation_::_%n seconds after creation_" : ["%n Sekunde nach Erstellung","%n Sekunden nach Erstellung"],
     "Create" : "Anlegen",
+    "_In %n second_::_In %n seconds_" : ["In %n Sekunde","In %n Sekunden"],
     "All aliases" : "Alle Aliases",
     "Disabled" : "Deaktiviert",
     "Loading..." : "Lade...",
@@ -60,6 +63,7 @@
     "Set your target mail domain and alias id lengths." : "Konfiguriere deine Ziel-Domäne und wähle die Längen der Alias IDs.",
     "Target mail domain" : "Ziel-Mail-Domäne",
     "Length of user alias ids (only for new users)" : "Länge der User Alias IDs (nur bei neuen Benutzern)",
-    "Length of alias ids (only for new aliases)" : "Länge der Alias IDs (nur bei neuen Aliases)"
+    "Length of alias ids (only for new aliases)" : "Länge der Alias IDs (nur bei neuen Aliases)",
+    "Time until alias changes are valid (ready time in seconds)" : "Zeit bis Änderungen an Aliases gültig sind (in Sekunden)"
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/l10n/de_DE.js
+++ b/l10n/de_DE.js
@@ -42,6 +42,7 @@ OC.L10N.register(
     "Enabled" : "Aktiviert",
     "Created" : "Erstellt",
     "Last Modified" : "Zuletzt geändert",
+    "Ready" : "Bereit",
     "Alias name" : "Alias-Name",
     "Send to address" : "Ziel-Adresse",
     "Comment" : "Notizen",
@@ -54,7 +55,9 @@ OC.L10N.register(
     "No" : "Nein",
     "New alias" : "Neuer Alias",
     "Now" : "Jetzt",
+    "_%n second after creation_::_%n seconds after creation_" : ["%n Sekunde nach Erstellung","%n Sekunden nach Erstellung"],
     "Create" : "Anlegen",
+    "_In %n second_::_In %n seconds_" : ["In %n Sekunde","In %n Sekunden"],
     "All aliases" : "Alle Aliases",
     "Disabled" : "Deaktiviert",
     "Loading..." : "Lade...",
@@ -62,6 +65,7 @@ OC.L10N.register(
     "Set your target mail domain and alias id lengths." : "Konfigurieren Sie Ihre Ziel-Domäne und wählen Sie die Längen der Alias IDs.",
     "Target mail domain" : "Ziel-Mail-Domäne",
     "Length of user alias ids (only for new users)" : "Länge der User Alias IDs (nur bei neuen Benutzern)",
-    "Length of alias ids (only for new aliases)" : "Länge der Alias IDs (nur bei neuen Aliases)"
+    "Length of alias ids (only for new aliases)" : "Länge der Alias IDs (nur bei neuen Aliases)",
+    "Time until alias changes are valid (ready time in seconds)" : "Zeit bis Änderungen an Aliases gültig sind (in Sekunden)"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -40,6 +40,7 @@
     "Enabled" : "Aktiviert",
     "Created" : "Erstellt",
     "Last Modified" : "Zuletzt geändert",
+    "Ready" : "Bereit",
     "Alias name" : "Alias-Name",
     "Send to address" : "Ziel-Adresse",
     "Comment" : "Notizen",
@@ -52,7 +53,9 @@
     "No" : "Nein",
     "New alias" : "Neuer Alias",
     "Now" : "Jetzt",
+    "_%n second after creation_::_%n seconds after creation_" : ["%n Sekunde nach Erstellung","%n Sekunden nach Erstellung"],
     "Create" : "Anlegen",
+    "_In %n second_::_In %n seconds_" : ["In %n Sekunde","In %n Sekunden"],
     "All aliases" : "Alle Aliases",
     "Disabled" : "Deaktiviert",
     "Loading..." : "Lade...",
@@ -60,6 +63,7 @@
     "Set your target mail domain and alias id lengths." : "Konfigurieren Sie Ihre Ziel-Domäne und wählen Sie die Längen der Alias IDs.",
     "Target mail domain" : "Ziel-Mail-Domäne",
     "Length of user alias ids (only for new users)" : "Länge der User Alias IDs (nur bei neuen Benutzern)",
-    "Length of alias ids (only for new aliases)" : "Länge der Alias IDs (nur bei neuen Aliases)"
+    "Length of alias ids (only for new aliases)" : "Länge der Alias IDs (nur bei neuen Aliases)",
+    "Time until alias changes are valid (ready time in seconds)" : "Zeit bis Änderungen an Aliases gültig sind (in Sekunden)"
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -50,13 +50,17 @@ class ConfigController extends Controller {
 	
 	/**
 	 * @param string $domain
+     * @param int $userAliasIdLen
+     * @param int $aliasIdLen
+     * @param int $readyTime
 	 */
-	public function setConf(string $domain, int $userAliasIdLen, int $aliasIdLen) {
+	public function setConf(string $domain, int $userAliasIdLen, int $aliasIdLen, int $readyTime) {
 	    return $this->handleConfigException(
-	        function () use ($domain, $userAliasIdLen, $aliasIdLen) {
+	        function () use ($domain, $userAliasIdLen, $aliasIdLen, $readyTime) {
 	            $this->service->setTargetDomain($domain);
 	            $this->service->setUserAliasIdLen($userAliasIdLen);
 	            $this->service->setAliasIdLen($aliasIdLen);
+	            $this->service->setReadyTime($readyTime);
 	        },
 	        function () {
 	            return $this->service->getConf();

--- a/lib/Db/Alias.php
+++ b/lib/Db/Alias.php
@@ -60,6 +60,8 @@ class Alias extends Entity {
             'enabled' => $this->enabled,
             'created' => $formatter->formatDateTime($this->created, 'short', 'medium'),
             'last_modified' => $formatter->formatDateTime($this->lastModified, 'short', 'medium'),
+            'created_utc' => $this->created,
+            'last_modified_utc' => $this->lastModified
         ];
     }
     

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -44,6 +44,9 @@ class ConfigService {
     public const MAX_TO_MAIL_LEN = 256;
     public const MAX_COMMENT_LEN = 40;
     public const MAX_ALIAS_RESULTS = 30;
+
+    public const MIN_READY_TIME = 0;
+    public const DEF_READY_TIME = 60;
     
     private $config;
     private $appName;
@@ -68,7 +71,9 @@ class ConfigService {
             'aliasNameLenMax' => self::MAX_ALIAS_NAME_LEN,
             'toMailLenMax' => self::MAX_TO_MAIL_LEN,
             'commentLenMax' => self::MAX_COMMENT_LEN,
-            'maxAliasResults' => self::MAX_ALIAS_RESULTS
+            'maxAliasResults' => self::MAX_ALIAS_RESULTS,
+            'readyTime' => $this->getReadyTime(),
+            'readyTimeMin' => self::MIN_READY_TIME
         );
     }
     
@@ -82,6 +87,10 @@ class ConfigService {
     
     public function getAliasIdLen(): int {
         return (int)$this->config->getAppValue($this->appName, 'aliasIdLen', self::DEF_ALIAS_ID_LEN);
+    }
+
+    public function getReadyTime(): int {
+        return (int)$this->config->getAppValue($this->appName, 'readyTime', self::DEF_READY_TIME);
     }
     
     /**
@@ -113,5 +122,15 @@ class ConfigService {
             throw new Exceptions\ValueBoundException("Alias id length has to be between ".self::MIN_USER_ALIAS_ID_LEN." and ".self::MAX_USER_ALIAS_ID_LEN);
             
         $this->config->setAppValue($this->appName, 'aliasIdLen', $len);
+    }
+
+    /**
+     * @param int $readyTime
+     */
+    public function setReadyTime(int $readyTime) {
+        if($readyTime < self::MIN_READY_TIME)
+            throw new Exceptions\ValueBoundException("Ready time has to be not lower than ".self::MIN_READY_TIME);
+
+        $this->config->setAppValue($this->appName, 'readyTime', $readyTime);
     }
 }

--- a/src/endpoints.js
+++ b/src/endpoints.js
@@ -42,12 +42,13 @@ export async function postmagGetConfig() {
         return config.data;
 }
 
-export function postmagPutConfig(domain, userAliasIdLen, aliasIdLen) {
+export function postmagPutConfig(domain, userAliasIdLen, aliasIdLen, readyTime) {
     const url = generateUrl('apps/postmag/config');
     const req = {
         domain: domain,
         userAliasIdLen: userAliasIdLen,
-        aliasIdLen: aliasIdLen
+        aliasIdLen: aliasIdLen,
+        readyTime: readyTime
     };
 
     axios.put(url, req)

--- a/src/settingsAdmin.js
+++ b/src/settingsAdmin.js
@@ -24,18 +24,20 @@ import { postmagPutConfig } from "./endpoints";
 
 $(function() {
 	$("body").on("change",
-		"input#postmagDomain, input#postmagUserAliasIdLen, input#postmagAliasIdLen",
+		"input#postmagDomain, input#postmagUserAliasIdLen, input#postmagAliasIdLen, input#postmagReadyTime",
 		function(e){
 			const domain = $("input#postmagDomain");
 			const userAliasIdLen = $("input#postmagUserAliasIdLen");
 			const aliasIdLen = $("input#postmagAliasIdLen");
+			const readyTime = $("input#postmagReadyTime");
 
 			if(
 				domain[0].validity.valid &&
 				userAliasIdLen[0].validity.valid &&
-				aliasIdLen[0].validity.valid
+				aliasIdLen[0].validity.valid &&
+				readyTime[0].validity.valid
 			){
-				postmagPutConfig(domain.val(), userAliasIdLen.val(), aliasIdLen.val());
+				postmagPutConfig(domain.val(), userAliasIdLen.val(), aliasIdLen.val(), readyTime.val());
 			}
 		}
 	)

--- a/templates/settingsAdmin.php
+++ b/templates/settingsAdmin.php
@@ -49,4 +49,11 @@ script('postmag', 'settingsAdmin');
 		min="<?php p($_['aliasIdLenMin']); ?>"
 		max="<?php p($_['aliasIdLenMax']); ?>"
         required/><br/>
+
+    <label for="postmagReadyTime"><?php p($l->t('Time until alias changes are valid (ready time in seconds)')); ?></label><br/>
+    <input id="postmagReadyTime"
+       type="number"
+       value="<?php p($_['readyTime']); ?>"
+       min="<?php p($_['readyTimeMin']); ?>"
+       required/><br/>
 </div>

--- a/tests/Integration/Controller/AliasControllerTest.php
+++ b/tests/Integration/Controller/AliasControllerTest.php
@@ -119,6 +119,8 @@ class AliasControllerTest extends TestCase {
                         $actual['last_modified'],
                         strval($actual['id']).' has not the expected last modified timestamp'
                         );
+                    $this->assertSame($expected->getCreated(), $actual['created_utc'], strval($actual['id']).' has not the expected created utc timestamp');
+                    $this->assertSame($expected->getLastModified(), $actual['last_modified_utc'], strval($actual['id']).' has not the expected last modified utc timestamp');
                     
                     $found = true;
                     break;
@@ -160,6 +162,8 @@ class AliasControllerTest extends TestCase {
             $ret->getData()['last_modified'],
             'Alias has not the expected last modified timestamp'
             );
+        $this->assertSame($now->getTimestamp(), $ret->getData()['created_utc'], 'Alias has not the expected created utc timestamp');
+        $this->assertSame($now->getTimestamp(), $ret->getData()['last_modified_utc'], 'Alias has not the expected last modified utc timestamp');
     }
 
     public function testRead() {
@@ -183,6 +187,8 @@ class AliasControllerTest extends TestCase {
             $ret->getData()['last_modified'],
             'Alias has not the expected last modified timestamp'
         );
+        $this->assertSame($this->aliases[0]->getCreated(), $ret->getData()['created_utc'],'Alias has not the expected created utc timestamp');
+        $this->assertSame($this->aliases[0]->getLastModified(), $ret->getData()['last_modified_utc'], 'Alias has not the expected last modified utc timestamp');
     }
 
     public function testReadNotFound() {
@@ -219,6 +225,8 @@ class AliasControllerTest extends TestCase {
             $ret->getData()['last_modified'],
             'Alias has not the expected last modified timestamp'
             );
+        $this->assertSame($this->aliases[0]->getCreated(), $ret->getData()['created_utc'], 'Alias has not the expected created utc timestamp');
+        $this->assertSame($now->getTimestamp(), $ret->getData()['last_modified_utc'], 'Alias has not the expected last modified utc timestamp');
     }
 
     public function testUpdateNotFound() {
@@ -257,6 +265,8 @@ class AliasControllerTest extends TestCase {
             $ret->getData()['last_modified'],
             'Alias has not the expected last modified timestamp'
             );
+        $this->assertSame($alias->getCreated(), $ret->getData()['created_utc'], 'Alias has not the expected created utc timestamp');
+        $this->assertSame($alias->getLastModified(), $ret->getData()['last_modified_utc'], 'Alias has not the expected last modified utc timestamp');
     }
 
     public function testDeleteNotFound() {

--- a/tests/Integration/Controller/ConfigControllerTest.php
+++ b/tests/Integration/Controller/ConfigControllerTest.php
@@ -56,7 +56,8 @@ class ConfigControllerTest extends TestCase {
         $this->controller->setConf(
             $this->confCache['domain'],
             $this->confCache['userAliasIdLen'],
-            $this->confCache['aliasIdLen']
+            $this->confCache['aliasIdLen'],
+            $this->confCache['readyTime']
             );
         
         parent::tearDown();
@@ -78,14 +79,16 @@ class ConfigControllerTest extends TestCase {
         $newDomain = 'mydomain.org';
         $newUserAliasIdLen = 6;
         $newAliasIdLen = 5;
+        $newReadyTime = 10;
         
-        $ret = $this->controller->setConf($newDomain, $newUserAliasIdLen, $newAliasIdLen);
+        $ret = $this->controller->setConf($newDomain, $newUserAliasIdLen, $newAliasIdLen, $newReadyTime);
         
         $this->assertTrue($ret instanceof JSONResponse, 'Result should be a JSON response.');
         $this->assertSame(Http::STATUS_OK, $ret->getStatus(), 'HTTP status should be OK.');
         $this->assertSame($newDomain, $ret->getData()['domain'], 'Did not return the expected domain.');
         $this->assertSame($newUserAliasIdLen, $ret->getData()['userAliasIdLen'], 'Did not return the expected user alias id len.');
         $this->assertSame($newAliasIdLen, $ret->getData()['aliasIdLen'], 'Did not return the expected alias id len.');
+        $this->assertSame($newReadyTime, $ret->getData()['readyTime'], 'Did not return the expected ready time.');
     }
     
 }

--- a/tests/Unit/Controller/AliasControllerTest.php
+++ b/tests/Unit/Controller/AliasControllerTest.php
@@ -60,6 +60,8 @@ class AliasControllerTest extends TestCase {
         $this->aliases[0]['enabled'] = true;
         $this->aliases[0]['created'] = '2020-01-01 12:34:56';
         $this->aliases[0]['last_modified'] = '2020-02-02 12:34:56';
+        $this->aliases[0]['created_utc'] = 1577878496;
+        $this->aliases[0]['last_modified_utc'] = 1580643296;
         
         $this->aliases[1]['id'] = 236;
         $this->aliases[1]['user_id'] = 'jane';
@@ -70,6 +72,8 @@ class AliasControllerTest extends TestCase {
         $this->aliases[1]['enabled'] = true;
         $this->aliases[1]['created'] = '2020-05-12 12:34:56';
         $this->aliases[1]['last_modified'] = '2020-08-10 12:34:56';
+        $this->aliases[1]['created_utc'] = 1589279696;
+        $this->aliases[1]['last_modified_utc'] = 1597055696;
     }
     
     public function testIndex() {
@@ -81,8 +85,8 @@ class AliasControllerTest extends TestCase {
                 if ($alias['user_id'] === $userId) {
                     $ret[] = $alias;
                 }
-                return $ret;
             }
+            return $ret;
         };
         
         $this->service->expects($this->once())
@@ -91,7 +95,7 @@ class AliasControllerTest extends TestCase {
         
         // Test method
         $ret = $this->controller->index($firstResult, $maxResults);
-            
+
         $this->assertTrue($ret instanceof JSONResponse, 'Result should be a JSON response.');
         $this->assertSame(Http::STATUS_OK, $ret->getStatus(), 'HTTP status should be OK.');
         $this->assertSame($findAll($firstResult, $maxResults, $this->userId), $ret->getData(), 'Did not return the expected aliases.');

--- a/tests/Unit/Controller/ConfigControllerTest.php
+++ b/tests/Unit/Controller/ConfigControllerTest.php
@@ -65,6 +65,7 @@ class ConfigControllerTest extends TestCase {
         $newDomain = 'mydomain.org';
         $newUserAliasIdLen = 6;
         $newAliasIdLen = 5;
+        $newReadyTime = 10;
         
         // Mocking
         $this->service->expects($this->once())
@@ -78,13 +79,17 @@ class ConfigControllerTest extends TestCase {
         $this->service->expects($this->once())
             ->method('setAliasIdLen')
             ->with($newAliasIdLen);
-        
+
+        $this->service->expects($this->once())
+            ->method('setReadyTime')
+            ->with($newReadyTime);
             
-        $getConf = function() use ($newDomain, $newUserAliasIdLen, $newAliasIdLen) {
+        $getConf = function() use ($newDomain, $newUserAliasIdLen, $newAliasIdLen, $newReadyTime) {
             $ret = ConfigServiceTest::CONF_DEFAULTS;
             $ret['domain'] = $newDomain;
             $ret['userAliasIdLen'] = $newUserAliasIdLen;
             $ret['aliasIdLen'] = $newAliasIdLen;
+            $ret['readyTime'] = $newReadyTime;
             
             return $ret;
         };
@@ -93,7 +98,7 @@ class ConfigControllerTest extends TestCase {
             ->willReturnCallback($getConf);
         
         // Test method
-        $ret = $this->controller->setConf($newDomain, $newUserAliasIdLen, $newAliasIdLen);
+        $ret = $this->controller->setConf($newDomain, $newUserAliasIdLen, $newAliasIdLen, $newReadyTime);
         
         $this->assertTrue($ret instanceof JSONResponse, 'Result should be a JSON response.');
         $this->assertSame(Http::STATUS_OK, $ret->getStatus(), 'HTTP status should be OK.');
@@ -104,6 +109,7 @@ class ConfigControllerTest extends TestCase {
         $newDomain = '.org';
         $newUserAliasIdLen = 6;
         $newAliasIdLen = 5;
+        $newReadyTime = 10;
         $exceptionMsg = 'Domain not valid.';
         
         // Mocking
@@ -119,9 +125,13 @@ class ConfigControllerTest extends TestCase {
         $this->service->expects($this->any())
             ->method('setAliasIdLen')
             ->with($newAliasIdLen);
+
+        $this->service->expects($this->any())
+            ->method('setReadyTime')
+            ->with($newReadyTime);
         
         // Test method
-        $ret = $this->controller->setConf($newDomain, $newUserAliasIdLen, $newAliasIdLen);
+        $ret = $this->controller->setConf($newDomain, $newUserAliasIdLen, $newAliasIdLen, $newReadyTime);
         
         $this->assertTrue($ret instanceof JSONResponse, 'Result should be a JSON response.');
         $this->assertSame(Http::STATUS_BAD_REQUEST, $ret->getStatus(), 'HTTP status should be BAD_REQUEST.');
@@ -132,6 +142,7 @@ class ConfigControllerTest extends TestCase {
         $newDomain = 'mydomain.org';
         $newUserAliasIdLen = 20;
         $newAliasIdLen = 5;
+        $newReadyTime = 10;
         $exceptionMsg = 'Length not valid.';
         
         // Mocking
@@ -147,9 +158,13 @@ class ConfigControllerTest extends TestCase {
         $this->service->expects($this->any())
             ->method('setAliasIdLen')
             ->with($newAliasIdLen);
+
+        $this->service->expects($this->any())
+            ->method('setReadyTime')
+            ->with($newReadyTime);
         
         // Test method
-        $ret = $this->controller->setConf($newDomain, $newUserAliasIdLen, $newAliasIdLen);
+        $ret = $this->controller->setConf($newDomain, $newUserAliasIdLen, $newAliasIdLen, $newReadyTime);
         
         $this->assertTrue($ret instanceof JSONResponse, 'Result should be a JSON response.');
         $this->assertSame(Http::STATUS_BAD_REQUEST, $ret->getStatus(), 'HTTP status should be BAD_REQUEST.');
@@ -160,6 +175,7 @@ class ConfigControllerTest extends TestCase {
         $newDomain = 'mydomain.org';
         $newUserAliasIdLen = 6;
         $newAliasIdLen = 20;
+        $newReadyTime = 10;
         $exceptionMsg = 'Length not valid.';
         
         // Mocking
@@ -175,10 +191,47 @@ class ConfigControllerTest extends TestCase {
             ->method('setAliasIdLen')
             ->with($newAliasIdLen)
             ->willThrowException(new ValueBoundException($exceptionMsg));
+
+        $this->service->expects($this->any())
+            ->method('setReadyTime')
+            ->with($newReadyTime);
         
         // Test method
-        $ret = $this->controller->setConf($newDomain, $newUserAliasIdLen, $newAliasIdLen);
+        $ret = $this->controller->setConf($newDomain, $newUserAliasIdLen, $newAliasIdLen, $newReadyTime);
         
+        $this->assertTrue($ret instanceof JSONResponse, 'Result should be a JSON response.');
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $ret->getStatus(), 'HTTP status should be BAD_REQUEST.');
+        $this->assertSame(['message' => $exceptionMsg], $ret->getData(), 'Did not return the exception message.');
+    }
+
+    public function testSetConfReadyTimeException(): void {
+        $newDomain = 'mydomain.org';
+        $newUserAliasIdLen = 6;
+        $newAliasIdLen = 5;
+        $newReadyTime = -1;
+        $exceptionMsg = 'Ready time not valid.';
+
+        // Mocking
+        $this->service->expects($this->any())
+            ->method('setTargetDomain')
+            ->with($newDomain);
+
+        $this->service->expects($this->any())
+            ->method('setUserAliasIdLen')
+            ->with($newUserAliasIdLen);
+
+        $this->service->expects($this->any())
+            ->method('setAliasIdLen')
+            ->with($newAliasIdLen);
+
+        $this->service->expects($this->any())
+            ->method('setReadyTime')
+            ->with($newReadyTime)
+            ->willThrowException(new ValueBoundException($exceptionMsg));
+
+        // Test method
+        $ret = $this->controller->setConf($newDomain, $newUserAliasIdLen, $newAliasIdLen, $newReadyTime);
+
         $this->assertTrue($ret instanceof JSONResponse, 'Result should be a JSON response.');
         $this->assertSame(Http::STATUS_BAD_REQUEST, $ret->getStatus(), 'HTTP status should be BAD_REQUEST.');
         $this->assertSame(['message' => $exceptionMsg], $ret->getData(), 'Did not return the exception message.');

--- a/tests/Unit/Service/AliasServiceTest.php
+++ b/tests/Unit/Service/AliasServiceTest.php
@@ -180,6 +180,8 @@ class AliasServiceTest extends TestCase {
         $this->assertSame($this->aliases[0]->getEnabled(), $ret[0]['enabled'], 'not the expected enabled state.');
         $this->assertSame($this->formatDTCallback($this->aliases[0]->getCreated(), 'short', 'medium'), $ret[0]['created'], 'not the expected created timestamp.');
         $this->assertSame($this->formatDTCallback($this->aliases[0]->getLastModified(), 'short', 'medium'), $ret[0]['last_modified'], 'not the expected last modified timestamp.');
+        $this->assertSame($this->aliases[0]->getCreated(), $ret[0]['created_utc'], 'not the expected created utc timestamp.');
+        $this->assertSame($this->aliases[0]->getLastModified(), $ret[0]['last_modified_utc'], 'not the expected created utc timestamp.');
     }
     
     public function testCreate(): void {
@@ -218,9 +220,12 @@ class AliasServiceTest extends TestCase {
         
         // Check timestamps
         // Unit tests are that fast, that this now timestamp is equal to the now timestamp in service->create. I'm sure...
-        $now = $this->formatDTCallback((new \DateTime("now"))->getTimestamp(), 'short', 'medium');
+        $nowUTC = (new \DateTime("now"))->getTimestamp();
+        $now = $this->formatDTCallback($nowUTC, 'short', 'medium');
         $this->assertSame($now, $ret['created'], 'created timestamp not set correctly.');
         $this->assertSame($now, $ret['last_modified'], 'last modified timestamp not set correctly.');
+        $this->assertSame($nowUTC, $ret['created_utc'], 'created utc timestamp not set correctly.');
+        $this->assertSame($nowUTC, $ret['last_modified_utc'], 'last modified utc timestamp not set correctly.');
         
         // Check other data
         $this->assertSame($this->aliases[0]->getUserId(), $ret['user_id'], 'not the expected user id.');
@@ -249,6 +254,8 @@ class AliasServiceTest extends TestCase {
         $this->assertSame($this->aliases[0]->getEnabled(), $ret['enabled'], 'not the expected enabled state.');
         $this->assertSame($this->formatDTCallback($this->aliases[0]->getCreated(), 'short', 'medium'), $ret['created'], 'not the expected created timestamp.');
         $this->assertSame($this->formatDTCallback($this->aliases[0]->getLastModified(), 'short', 'medium'), $ret['last_modified'], 'not the expected last modified timestamp.');
+        $this->assertSame($this->aliases[0]->getCreated(), $ret['created_utc'], 'not the expected created utc timestamp.');
+        $this->assertSame($this->aliases[0]->getLastModified(), $ret['last_modified_utc'], 'not the expected last modified utc timestamp.');
     }
 
     public function testFindNotFound() {
@@ -294,9 +301,12 @@ class AliasServiceTest extends TestCase {
         
         // Check timestamps
         // Unit tests are that fast, that this now timestamp is equal to the now timestamp in service->create. I'm sure...
-        $now = $this->formatDTCallback((new \DateTime("now"))->getTimestamp(), 'short', 'medium');
+        $nowUTC = (new \DateTime("now"))->getTimestamp();
+        $now = $this->formatDTCallback($nowUTC, 'short', 'medium');
         $this->assertSame($this->formatDTCallback($this->aliases[0]->getCreated(), 'short', 'medium'), $ret['created'], 'created timestamp was changed.');
         $this->assertSame($now, $ret['last_modified'], 'last modified timestamp not set correctly.');
+        $this->assertSame($this->aliases[0]->getCreated(), $ret['created_utc'], 'created utc timestamp was changed.');
+        $this->assertSame($nowUTC, $ret['last_modified_utc'], 'last modified utc timestamp not set correctly.');
         
         // Check other data
         $this->assertSame($this->aliases[0]->getUserId(), $ret['user_id'], 'not the expected user id.');
@@ -350,6 +360,8 @@ class AliasServiceTest extends TestCase {
         // Check timestamps
         $this->assertSame($this->formatDTCallback($this->aliases[0]->getCreated(), 'short', 'medium'), $ret['created'], 'created timestamp was changed.');
         $this->assertSame($this->formatDTCallback($this->aliases[0]->getLastModified(), 'short', 'medium'), $ret['last_modified'], 'last modified timestamp was changed.');
+        $this->assertSame($this->aliases[0]->getCreated(), $ret['created_utc'], 'created utc timestamp was changed.');
+        $this->assertSame($this->aliases[0]->getLastModified(), $ret['last_modified_utc'], 'last modified utc timestamp was changed.');
         
         // Check other data
         $this->assertSame($this->aliases[0]->getUserId(), $ret['user_id'], 'not the expected user id.');

--- a/translationfiles/de/postmag.po
+++ b/translationfiles/de/postmag.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Nextcloud 3.14159\n"
 "Report-Msgid-Bugs-To: translations\\@example.com\n"
-"POT-Creation-Date: 2021-07-10 15:41+0200\n"
-"PO-Revision-Date: 2021-07-10 15:49+0200\n"
+"POT-Creation-Date: 2021-07-13 20:48+0200\n"
+"PO-Revision-Date: 2021-07-13 20:52+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: de\n"
@@ -81,75 +81,75 @@ msgstr "Fehler beim Laden der Konfiguration ({status})"
 msgid "Error on Postmag config load (unknown error)."
 msgstr "Fehler beim Laden der Konfiguration (unbekannt)."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:55
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:56
 msgid "Postmag settings changed successfully!"
 msgstr "Einstellungen erfolgreich geändert!"
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:59
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:60
 msgid "Error on Postmag settings change ({status})."
 msgstr "Fehler beim Ändern der Einstellungen ({status})."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:62
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:63
 msgid "Error on Postmag settings change (unknown error)."
 msgstr "Fehler beim Ändern der Einstellungen (unbekannt)."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:72
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:73
 msgid "Error on Postmag user info load ({status})."
 msgstr "Fehler beim Laden der Benutzerinformationen ({status})."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:75
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:76
 msgid "Error on Postmag user info load (unknown error)."
 msgstr "Fehler beim Laden der Benutzerinformationen (unbekannt)."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:93
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:94
 msgid "Error on Postmag alias load ({status})."
 msgstr "Fehler beim Laden der Aliases ({status})."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:96
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:97
 msgid "Error on Postmag alias load (unknown error)."
 msgstr "Fehler beim Laden der Aliases (unbekannt)."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:117
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:118
 msgid "Error on alias creation ({status})."
 msgstr "Fehler beim Anlegen des Aliases ({status})."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:120
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:121
 msgid "Error on alias creation (unknown error)."
 msgstr "Fehler beim Anlegen des Aliases (unbekannt)."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:136
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:137
 msgid "Error on alias read ({status})."
 msgstr "Fehler beim Lesen des Aliases ({status})."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:139
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:140
 msgid "Error on alias read (unknown error)."
 msgstr "Fehler beim Lesen des Aliases (unbekannt)."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:160
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:161
 msgid "Error on alias update ({status})."
 msgstr "Fehler beim Aktualisieren des Aliases ({status})."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:163
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:164
 msgid "Error on alias update (unknown error)."
 msgstr "Fehler beim Aktualisieren des Aliases (unbekannt)."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:179
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:180
 msgid "Error on alias delete ({status})."
 msgstr "Fehler beim Löschen des Aliases ({status})."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:182
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:183
 msgid "Error on alias delete (unknown error)."
 msgstr "Fehler beim Löschen des Aliases (unbekannt)."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:198
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:199
 msgid "Sent test message to alias."
 msgstr "Testnachricht gesendet."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:202
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:203
 msgid "Error on sending test message ({status})."
 msgstr "Fehler beim Senden der Testnachricht ({status})."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:205
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:206
 msgid "Error on sending test message (unknown error)."
 msgstr "Fehler beim Senden der Testnachricht (unbekannt)."
 
@@ -197,35 +197,39 @@ msgid "Last Modified"
 msgstr "Zuletzt geändert"
 
 #: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:56
+msgid "Ready"
+msgstr "Bereit"
+
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:59
 msgid "Alias name"
 msgstr "Alias-Name"
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:59
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:62
 msgid "Send to address"
 msgstr "Ziel-Adresse"
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:62
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:65
 msgid "Comment"
 msgstr "Notizen"
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:67
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:139
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:70
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:151
 msgid "Apply"
 msgstr "Übernehmen"
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:74
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:77
 msgid "Delete {aliasHead}?"
 msgstr "{aliasHead} löschen?"
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:76
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:79
 msgid "Are you sure you want to delete this alias?"
 msgstr "Bist du sicher, dass du diesen Alias löschen möchtest?"
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:77
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:80
 msgid "Deleted aliases cannot be restored."
 msgstr "Gelöschte Aliases können nicht wiederhergestellt werden."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:78
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:81
 msgid ""
 "Consider disabling the alias if you don't want to receive mails via it "
 "anymore."
@@ -233,28 +237,41 @@ msgstr ""
 "Aliases können auch deaktiviert werden, wenn du keine E-Mails mehr über sie "
 "empfangen möchtest."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:80
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:83
 msgid "Yes"
 msgstr "Ja"
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:81
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:84
 msgid "No"
 msgstr "Nein"
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:103
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:161
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:106
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:203
 #: /home/patrick/PHPStormProjects/postmag-nc/templates/index.php:30
 msgid "New alias"
 msgstr "Neuer Alias"
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:106
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:107
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:109
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:110
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:168
 msgid "Now"
 msgstr "Jetzt"
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:114
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:113
+msgid "%n second after creation"
+msgid_plural "%n seconds after creation"
+msgstr[0] "%n Sekunde nach Erstellung"
+msgstr[1] "%n Sekunden nach Erstellung"
+
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:124
 msgid "Create"
 msgstr "Anlegen"
+
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:175
+msgid "In %n second"
+msgid_plural "In %n seconds"
+msgstr[0] "In %n Sekunde"
+msgstr[1] "In %n Sekunden"
 
 #: /home/patrick/PHPStormProjects/postmag-nc/templates/index.php:35
 msgid "All aliases"
@@ -287,3 +304,7 @@ msgstr "Länge der User Alias IDs (nur bei neuen Benutzern)"
 #: /home/patrick/PHPStormProjects/postmag-nc/templates/settingsAdmin.php:45
 msgid "Length of alias ids (only for new aliases)"
 msgstr "Länge der Alias IDs (nur bei neuen Aliases)"
+
+#: /home/patrick/PHPStormProjects/postmag-nc/templates/settingsAdmin.php:53
+msgid "Time until alias changes are valid (ready time in seconds)"
+msgstr "Zeit bis Änderungen an Aliases gültig sind (in Sekunden)"

--- a/translationfiles/de_DE/postmag.po
+++ b/translationfiles/de_DE/postmag.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Nextcloud 3.14159\n"
 "Report-Msgid-Bugs-To: translations\\@example.com\n"
-"POT-Creation-Date: 2021-07-10 15:41+0200\n"
-"PO-Revision-Date: 2021-07-10 15:53+0200\n"
+"POT-Creation-Date: 2021-07-13 20:48+0200\n"
+"PO-Revision-Date: 2021-07-13 20:54+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: de\n"
@@ -81,75 +81,75 @@ msgstr "Fehler beim Laden der Konfiguration ({status})"
 msgid "Error on Postmag config load (unknown error)."
 msgstr "Fehler beim Laden der Konfiguration (unbekannt)."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:55
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:56
 msgid "Postmag settings changed successfully!"
 msgstr "Einstellungen erfolgreich geändert!"
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:59
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:60
 msgid "Error on Postmag settings change ({status})."
 msgstr "Fehler beim Ändern der Einstellungen ({status})."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:62
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:63
 msgid "Error on Postmag settings change (unknown error)."
 msgstr "Fehler beim Ändern der Einstellungen (unbekannt)."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:72
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:73
 msgid "Error on Postmag user info load ({status})."
 msgstr "Fehler beim Laden der Benutzerinformationen ({status})."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:75
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:76
 msgid "Error on Postmag user info load (unknown error)."
 msgstr "Fehler beim Laden der Benutzerinformationen (unbekannt)."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:93
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:94
 msgid "Error on Postmag alias load ({status})."
 msgstr "Fehler beim Laden der Aliases ({status})."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:96
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:97
 msgid "Error on Postmag alias load (unknown error)."
 msgstr "Fehler beim Laden der Aliases (unbekannt)."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:117
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:118
 msgid "Error on alias creation ({status})."
 msgstr "Fehler beim Anlegen des Aliases ({status})."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:120
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:121
 msgid "Error on alias creation (unknown error)."
 msgstr "Fehler beim Anlegen des Aliases (unbekannt)."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:136
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:137
 msgid "Error on alias read ({status})."
 msgstr "Fehler beim Lesen des Aliases ({status})."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:139
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:140
 msgid "Error on alias read (unknown error)."
 msgstr "Fehler beim Lesen des Aliases (unbekannt)."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:160
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:161
 msgid "Error on alias update ({status})."
 msgstr "Fehler beim Aktualisieren des Aliases ({status})."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:163
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:164
 msgid "Error on alias update (unknown error)."
 msgstr "Fehler beim Aktualisieren des Aliases (unbekannt)."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:179
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:180
 msgid "Error on alias delete ({status})."
 msgstr "Fehler beim Löschen des Aliases ({status})."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:182
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:183
 msgid "Error on alias delete (unknown error)."
 msgstr "Fehler beim Löschen des Aliases (unbekannt)."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:198
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:199
 msgid "Sent test message to alias."
 msgstr "Testnachricht gesendet."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:202
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:203
 msgid "Error on sending test message ({status})."
 msgstr "Fehler beim Senden der Testnachricht ({status})."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:205
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:206
 msgid "Error on sending test message (unknown error)."
 msgstr "Fehler beim Senden der Testnachricht (unbekannt)."
 
@@ -197,35 +197,39 @@ msgid "Last Modified"
 msgstr "Zuletzt geändert"
 
 #: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:56
+msgid "Ready"
+msgstr "Bereit"
+
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:59
 msgid "Alias name"
 msgstr "Alias-Name"
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:59
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:62
 msgid "Send to address"
 msgstr "Ziel-Adresse"
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:62
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:65
 msgid "Comment"
 msgstr "Notizen"
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:67
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:139
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:70
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:151
 msgid "Apply"
 msgstr "Übernehmen"
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:74
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:77
 msgid "Delete {aliasHead}?"
 msgstr "{aliasHead} löschen?"
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:76
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:79
 msgid "Are you sure you want to delete this alias?"
 msgstr "Sind Sie sicher, dass Sie diesen Alias löschen möchten?"
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:77
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:80
 msgid "Deleted aliases cannot be restored."
 msgstr "Gelöschte Aliases können nicht wiederhergestellt werden."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:78
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:81
 msgid ""
 "Consider disabling the alias if you don't want to receive mails via it "
 "anymore."
@@ -233,28 +237,41 @@ msgstr ""
 "Aliases können auch deaktiviert werden, wenn Sie keine E-Mails mehr über sie "
 "empfangen möchten."
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:80
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:83
 msgid "Yes"
 msgstr "Ja"
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:81
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:84
 msgid "No"
 msgstr "Nein"
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:103
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:161
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:106
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:203
 #: /home/patrick/PHPStormProjects/postmag-nc/templates/index.php:30
 msgid "New alias"
 msgstr "Neuer Alias"
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:106
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:107
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:109
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:110
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:168
 msgid "Now"
 msgstr "Jetzt"
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:114
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:113
+msgid "%n second after creation"
+msgid_plural "%n seconds after creation"
+msgstr[0] "%n Sekunde nach Erstellung"
+msgstr[1] "%n Sekunden nach Erstellung"
+
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:124
 msgid "Create"
 msgstr "Anlegen"
+
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:175
+msgid "In %n second"
+msgid_plural "In %n seconds"
+msgstr[0] "In %n Sekunde"
+msgstr[1] "In %n Sekunden"
 
 #: /home/patrick/PHPStormProjects/postmag-nc/templates/index.php:35
 msgid "All aliases"
@@ -288,3 +305,7 @@ msgstr "Länge der User Alias IDs (nur bei neuen Benutzern)"
 #: /home/patrick/PHPStormProjects/postmag-nc/templates/settingsAdmin.php:45
 msgid "Length of alias ids (only for new aliases)"
 msgstr "Länge der Alias IDs (nur bei neuen Aliases)"
+
+#: /home/patrick/PHPStormProjects/postmag-nc/templates/settingsAdmin.php:53
+msgid "Time until alias changes are valid (ready time in seconds)"
+msgstr "Zeit bis Änderungen an Aliases gültig sind (in Sekunden)"

--- a/translationfiles/templates/postmag.pot
+++ b/translationfiles/templates/postmag.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Nextcloud 3.14159\n"
 "Report-Msgid-Bugs-To: translations\\@example.com\n"
-"POT-Creation-Date: 2021-07-10 15:41+0200\n"
+"POT-Creation-Date: 2021-07-13 20:48+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
 #: /home/patrick/PHPStormProjects/postmag-nc/lib/Service/MailService.php:65
 #: /home/patrick/PHPStormProjects/postmag-nc/lib/Service/MailService.php:67
@@ -75,75 +76,75 @@ msgstr ""
 msgid "Error on Postmag config load (unknown error)."
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:55
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:56
 msgid "Postmag settings changed successfully!"
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:59
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:60
 msgid "Error on Postmag settings change ({status})."
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:62
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:63
 msgid "Error on Postmag settings change (unknown error)."
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:72
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:73
 msgid "Error on Postmag user info load ({status})."
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:75
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:76
 msgid "Error on Postmag user info load (unknown error)."
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:93
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:94
 msgid "Error on Postmag alias load ({status})."
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:96
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:97
 msgid "Error on Postmag alias load (unknown error)."
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:117
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:118
 msgid "Error on alias creation ({status})."
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:120
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:121
 msgid "Error on alias creation (unknown error)."
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:136
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:137
 msgid "Error on alias read ({status})."
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:139
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:140
 msgid "Error on alias read (unknown error)."
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:160
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:161
 msgid "Error on alias update ({status})."
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:163
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:164
 msgid "Error on alias update (unknown error)."
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:179
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:180
 msgid "Error on alias delete ({status})."
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:182
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:183
 msgid "Error on alias delete (unknown error)."
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:198
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:199
 msgid "Sent test message to alias."
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:202
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:203
 msgid "Error on sending test message ({status})."
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:205
+#: /home/patrick/PHPStormProjects/postmag-nc/src/endpoints.js:206
 msgid "Error on sending test message (unknown error)."
 msgstr ""
 
@@ -191,62 +192,79 @@ msgid "Last Modified"
 msgstr ""
 
 #: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:56
-msgid "Alias name"
+msgid "Ready"
 msgstr ""
 
 #: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:59
-msgid "Send to address"
+msgid "Alias name"
 msgstr ""
 
 #: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:62
+msgid "Send to address"
+msgstr ""
+
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:65
 msgid "Comment"
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:67
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:139
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:70
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:151
 msgid "Apply"
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:74
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:77
 msgid "Delete {aliasHead}?"
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:76
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:79
 msgid "Are you sure you want to delete this alias?"
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:77
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:80
 msgid "Deleted aliases cannot be restored."
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:78
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:81
 msgid ""
 "Consider disabling the alias if you don't want to receive mails via it "
 "anymore."
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:80
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:83
 msgid "Yes"
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:81
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:84
 msgid "No"
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:103
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:161
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:106
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:203
 #: /home/patrick/PHPStormProjects/postmag-nc/templates/index.php:30
 msgid "New alias"
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:106
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:107
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:109
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:110
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:168
 msgid "Now"
 msgstr ""
 
-#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:114
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:113
+msgid "%n second after creation"
+msgid_plural "%n seconds after creation"
+msgstr[0] ""
+msgstr[1] ""
+
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:124
 msgid "Create"
 msgstr ""
+
+#: /home/patrick/PHPStormProjects/postmag-nc/src/templates.js:175
+msgid "In %n second"
+msgid_plural "In %n seconds"
+msgstr[0] ""
+msgstr[1] ""
 
 #: /home/patrick/PHPStormProjects/postmag-nc/templates/index.php:35
 msgid "All aliases"
@@ -278,4 +296,8 @@ msgstr ""
 
 #: /home/patrick/PHPStormProjects/postmag-nc/templates/settingsAdmin.php:45
 msgid "Length of alias ids (only for new aliases)"
+msgstr ""
+
+#: /home/patrick/PHPStormProjects/postmag-nc/templates/settingsAdmin.php:53
+msgid "Time until alias changes are valid (ready time in seconds)"
 msgstr ""


### PR DESCRIPTION
This branch adds a message that counts down seconds until the aliases are ready. The time until the aliases are ready is configurable by the admin.

This is useful if you deploy the generated alias file of Postmag via a script that is triggered by crontab (or something similar). If you don't need this feature (for instance if you push the alias file directly on every change) you can set the ready time to 0.

Resolves #4.