### PR TITLE
create changelog file

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -16,6 +16,8 @@ screenshots
 /vendor
 
 /.eslintrc.js
+/CHANGELOG.json
+/CHANGELOG.md
 /composer.*
 /Makefile
 /package.json

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,0 +1,20 @@
+{
+  "1.1.0": {
+    "feature": [
+      "Add a button for sending test mails (#8)",
+      "Add a ready countdown that shows the user when an alias is ready (#9)"
+    ]
+  },
+  "1.1.1": {
+    "bug": [
+      "Update info.xml to the release version"
+    ]
+  },
+  "1.1.2": {
+    "bug": [
+      "Update Readme (#10)",
+      "Fix bug on ready countdown if one creates a new alias (#11)",
+      "Added branch protection and branch structure to prepare for CI/CD (Github Actions) and Dependabot."
+    ]
+  }
+}


### PR DESCRIPTION
Creates a changelog file and adds it to nextcloudignore.

The changelog will be updated automatically and converted to a markdown file by a github action (The needed information will be loaded from the commits of the PRs)

Resolves #17 