### PR TITLE
add github action for packaging app

### DIFF
--- a/.github/scripts/createRelease.py
+++ b/.github/scripts/createRelease.py
@@ -1,0 +1,65 @@
+#
+# @author Patrick Greyson
+#
+# Postmag - Postfix mail alias generator for Nextcloud
+# Copyright (C) 2021
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+import json
+import requests
+from uritemplate import expand
+
+# Get arguments
+token = sys.argv[1]
+version = sys.argv[2]
+pkgPath = sys.argv[3]
+body = sys.argv[4]
+
+# Some configs
+releasesEndpoint = "https://api.github.com/repos/" + os.environ["GITHUB_REPOSITORY"] + "/releases"
+releasesHeaders = {
+  "Accept": "application/vnd.github.v3+json",
+  "Authorization": "Bearer " + token
+}
+
+# create release
+createBody = {
+  "tag_name": "v" + version,
+  "name": "Release " + version,
+  "body": body
+}
+sys.stdout.write("Create release...\n")
+response = requests.post(releasesEndpoint, headers=releasesHeaders, json=createBody)
+if response.status_code != 201:
+  # Release was not created successfully
+  sys.stderr.write("Got no successful response from Github API for creating the release.\n")
+  sys.exit(1)
+
+# Upload package to release
+uploadEndpoint = expand(response.json()["upload_url"], name=pkgPath.split("/")[-1])
+releasesHeaders["Content-Type"] = "application/gzip"
+with open(pkgPath, 'rb') as pkgFile:
+  pkgData = pkgFile.read()
+sys.stdout.write("Upload release package...\n")
+response = requests.post(uploadEndpoint, headers=releasesHeaders, data=pkgData)
+if response.status_code != 201:
+  # Package was not uploaded successfully
+  sys.stderr.write("Got no successful response from Github API for uploading the release package.\n")
+  sys.exit(1)
+
+sys.stdout.write("Done!\n")
+sys.exit(0)

--- a/.github/workflows/package-app.yml
+++ b/.github/workflows/package-app.yml
@@ -1,0 +1,62 @@
+#
+# @author Patrick Greyson
+#
+# Postmag - Postfix mail alias generator for Nextcloud
+# Copyright (C) 2021
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Workflow for the app packaging
+name: package-app
+
+on:
+  push:
+    branches: [ main ]
+    
+  workflow_dispatch:
+
+jobs:
+  package-app:
+    runs-on: ubuntu-latest
+    env:
+      krankerl: 'https://github.com/ChristophWurst/krankerl/releases/download/v0.13.1/krankerl_0.13.1_amd64.deb'
+    steps:
+      # Checks-out repository under $GITHUB_WORKSPACE
+      - name: Checkout dev branch
+        uses: actions/checkout@v2
+        with:
+          ref: main
+          
+      - name: Download and install krankerl
+        run: |
+          cd /tmp
+          wget ${{ env.krankerl }}
+          sudo dpkg -i $(echo ${{ env.krankerl }} | rev | cut -f1 -d/ | rev)
+          
+      - name: Install Python deps
+        run: pip install uritemplate
+      
+      - name: Package app
+        run: |
+          cd $GITHUB_WORKSPACE
+          make package
+          
+      - name: Get app version
+        run: echo "app_version=$(echo $(grep -o '<version>[0-9]*\.[0-9]*\.[0-9]*</version>' $GITHUB_WORKSPACE/appinfo/info.xml) | grep -o '[0-9]*\.[0-9]*\.[0-9]*')" >> $GITHUB_ENV
+
+      - name: Create release on Github
+        run: |
+          cd /tmp
+          python $GITHUB_WORKSPACE/.github/scripts/genMdChangelog.py $GITHUB_WORKSPACE/.github/config/semantic_labels.json $GITHUB_WORKSPACE/CHANGELOG.json ${{ env.app_version }} > changelog.md
+          python $GITHUB_WORKSPACE/.github/scripts/createRelease.py ${{ github.token }} ${{ env.app_version }} $GITHUB_WORKSPACE/build/artifacts/postmag.tar.gz "$(cat changelog.md)"

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -16,5 +16,13 @@
       "Fix bug on ready countdown if one creates a new alias (#11)",
       "Added branch protection and branch structure to prepare for CI/CD (Github Actions) and Dependabot."
     ]
+  },
+  "1.1.4": {
+    "feature": [
+      "create changelog file (#26)",
+      "run app tests on pr into dev (#27)",
+      "add github action for checking semantic labels (#28)",
+      "add github action for implementing release cycle (#29)"
+    ]
   }
 }


### PR DESCRIPTION
This adds an action that packages the app and creates a github release if there are pushes on main. If it is needed, the action can also be triggered manually (but this should only be needed in case of an unexpected error).

Normally an release should be created by triggering the release cycle action!

Resolves #21