### PR TITLE
use svg icons for navigation bar to avoid overlapping labels

### DIFF
--- a/templates/index.php
+++ b/templates/index.php
@@ -32,9 +32,9 @@ script('postmag', 'aliasListHandler')
         </div>
 
         <ul class="with-icon">
-            <li><a id="postmagAliasFilterAll" href="#" class="icon-user active"><?php p($l->t('All aliases')); ?></a></li>
-            <li><a id="postmagAliasFilterEnabled" href="#" class="icon-checkmark"><?php p($l->t('Enabled')); ?></a></li>
-            <li><a id="postmagAliasFilterDisabled" href="#" class="icon-close"><?php p($l->t('Disabled')); ?></a></li>
+            <li><a id="postmagAliasFilterAll" href="#" class="icon-user svg active"><?php p($l->t('All aliases')); ?></a></li>
+            <li><a id="postmagAliasFilterEnabled" href="#" class="icon-checkmark svg"><?php p($l->t('Enabled')); ?></a></li>
+            <li><a id="postmagAliasFilterDisabled" href="#" class="icon-close svg"><?php p($l->t('Disabled')); ?></a></li>
         </ul>
 	</div>
 


### PR DESCRIPTION
Commit [d0afc49](https://github.com/nextcloud/server/commit/d0afc49df2c99bb02b65080b16d0a8468ef468bc) of Nextcloud server leads to overlapping labels in the navigation bar if svg icons are not used.

To fix this on my side, this PR adds the svg class to the menu entries.

Fixes #25 