### PR TITLE
make php tests more robust on timestamp and id checks

### DIFF
--- a/tests/Integration/Db/AliasMapperTest.php
+++ b/tests/Integration/Db/AliasMapperTest.php
@@ -156,7 +156,7 @@ class AliasMapperTest extends TestCase {
                 $this->testAliases[0]->getUserId(),
                 $this->testAliases[0]->getAliasName()
                 ),
-            'Alias id was allready present but not found.'
+            'Alias id was already present but not found.'
             );
         $this->assertFalse(
             $this->mapper->containsAliasId(

--- a/tests/Integration/Db/UserMapperTest.php
+++ b/tests/Integration/Db/UserMapperTest.php
@@ -26,8 +26,6 @@ namespace OCA\Postmag\Tests\Integration\Db;
 use Test\TestCase;
 use OCP\AppFramework\App;
 use OCA\Postmag\Db\User;
-use OCA\Postmag\Share\Random;
-use OCA\Postmag\Service\ConfigService;
 
 /**
  * @group DB
@@ -55,7 +53,7 @@ class UserMapperTest extends TestCase {
         // Create test user
         $this->testUser = new User();
         $this->testUser->setUserId($this->userId);
-        $this->testUser->setUserAliasId(Random::hexString(ConfigService::DEF_USER_ALIAS_ID_LEN));
+        $this->testUser->setUserAliasId('2a9f');
         
         // Insert user into database
         $this->insertedUser = $this->mapper->insert($this->testUser);

--- a/tests/Unit/Service/AliasServiceTest.php
+++ b/tests/Unit/Service/AliasServiceTest.php
@@ -219,13 +219,9 @@ class AliasServiceTest extends TestCase {
         $this->assertSame(ConfigService::DEF_USER_ALIAS_ID_LEN, strlen($ret['alias_id']), 'alias id is of wrong length.');
         
         // Check timestamps
-        // Unit tests are that fast, that this now timestamp is equal to the now timestamp in service->create. I'm sure...
         $nowUTC = (new \DateTime("now"))->getTimestamp();
-        $now = $this->formatDTCallback($nowUTC, 'short', 'medium');
-        $this->assertSame($now, $ret['created'], 'created timestamp not set correctly.');
-        $this->assertSame($now, $ret['last_modified'], 'last modified timestamp not set correctly.');
-        $this->assertSame($nowUTC, $ret['created_utc'], 'created utc timestamp not set correctly.');
-        $this->assertSame($nowUTC, $ret['last_modified_utc'], 'last modified utc timestamp not set correctly.');
+        $this->assertTrue(($nowUTC - $ret['created_utc']) < 10, 'created utc timestamp not set correctly.');
+        $this->assertTrue(($nowUTC - $ret['last_modified_utc']) < 10, 'last modified utc timestamp not set correctly.');
         
         // Check other data
         $this->assertSame($this->aliases[0]->getUserId(), $ret['user_id'], 'not the expected user id.');
@@ -300,13 +296,9 @@ class AliasServiceTest extends TestCase {
             );
         
         // Check timestamps
-        // Unit tests are that fast, that this now timestamp is equal to the now timestamp in service->create. I'm sure...
         $nowUTC = (new \DateTime("now"))->getTimestamp();
-        $now = $this->formatDTCallback($nowUTC, 'short', 'medium');
-        $this->assertSame($this->formatDTCallback($this->aliases[0]->getCreated(), 'short', 'medium'), $ret['created'], 'created timestamp was changed.');
-        $this->assertSame($now, $ret['last_modified'], 'last modified timestamp not set correctly.');
         $this->assertSame($this->aliases[0]->getCreated(), $ret['created_utc'], 'created utc timestamp was changed.');
-        $this->assertSame($nowUTC, $ret['last_modified_utc'], 'last modified utc timestamp not set correctly.');
+        $this->assertTrue(($nowUTC - $ret['last_modified_utc']) < 10, 'last modified utc timestamp not set correctly.');
         
         // Check other data
         $this->assertSame($this->aliases[0]->getUserId(), $ret['user_id'], 'not the expected user id.');


### PR DESCRIPTION
This PR makes some PHP tests more robust.

This was not a problem until I created automatic checks via GitHub Actions (because I just rerun the tests) but it can lead to confusing situations now (because I search for issues in my CI processes when there are none).

Fixes #24 