### PR TITLE
allow boolean fields to be nullable for oracle

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@
     <repository type="git">https://github.com/patrick1990/postmag-nc.git</repository>
     <screenshot>https://raw.githubusercontent.com/patrick1990/postmag-nc/main/screenshots/postmag.png</screenshot>
     <dependencies>
-        <nextcloud min-version="20" max-version="21"/>
+        <nextcloud min-version="20" max-version="22"/>
     </dependencies>
     <commands>
 		<command>OCA\Postmag\Command\Aliases</command>

--- a/lib/Migration/Version0001Date20201207124100.php
+++ b/lib/Migration/Version0001Date20201207124100.php
@@ -37,7 +37,7 @@ class Version0001Date20201207124100 extends SimpleMigrationStep {
      * @param array $options
      * @return null|ISchemaWrapper
      */
-    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
         /** @var ISchemaWrapper $schema */
         $schema = $schemaClosure();
         
@@ -93,7 +93,7 @@ class Version0001Date20201207124100 extends SimpleMigrationStep {
                 'length' => ConfigService::MAX_COMMENT_LEN
             ]);
             $table->addColumn('enabled', 'boolean', [
-                'notnull' => true,
+                'notnull' => false,
                 'default' => true
             ]);
             if (PHP_INT_SIZE >= 8) {

--- a/lib/Migration/Version0002Date20210817194000.php
+++ b/lib/Migration/Version0002Date20210817194000.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @author Patrick Greyson
+ *
+ * Postmag - Postfix mail alias generator for Nextcloud
+ * Copyright (C) 2021
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Postmag\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version0002Date20210817194000 extends SimpleMigrationStep {
+    
+    /**
+     * @param IOutput $output
+     * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+     * @param array $options
+     * @return null|ISchemaWrapper
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+        /** @var ISchemaWrapper $schema */
+        $schema = $schemaClosure();
+        $colAliasEnabled = $schema->getTable('postmag_alias')->getColumn('enabled');
+
+        if($colAliasEnabled->getNotnull()) {
+            $colAliasEnabled->setNotnull(false);
+            return $schema;
+        }
+        
+        return null;
+    }
+    
+}


### PR DESCRIPTION
NC 22 doesn't support non-nullable boolean fields because of Oracle DB.

See issue #22 for more details.

Fixes #22 