### PR TITLE
Automatic PR to support new NC versions

### DIFF
--- a/.github/config/semantic_labels.json
+++ b/.github/config/semantic_labels.json
@@ -1,6 +1,5 @@
-[
-  "dependencies",
-  "bug",
-  "feature",
-  "major"
-]
+{
+  "major": ["major"],
+  "minor": ["feature"],
+  "patch": ["bug", "dependencies"]
+}

--- a/.github/config/semantic_labels.json
+++ b/.github/config/semantic_labels.json
@@ -1,5 +1,5 @@
 {
-  "major": ["major"],
+  "major": ["nextcloud", "major"],
   "minor": ["feature"],
   "patch": ["bug", "dependencies"]
 }

--- a/.github/scripts/checkLabels.py
+++ b/.github/scripts/checkLabels.py
@@ -42,11 +42,12 @@ if response.status_code != 200:
   sys.exit(1)
 
 prLabels = response.json()["labels"]
-for semanticLabel in semanticLabels:
-  if semanticLabel in [prLabel["name"] for prLabel in prLabels]:
-    # Semantic label found --> Exit successfully
-    sys.stdout.write("Found label " + semanticLabel + " on PR " + prId + "\n")
-    sys.exit(0)
+for level in semanticLabels:
+    for semanticLabel in semanticLabels[level]:
+      if semanticLabel in [prLabel["name"] for prLabel in prLabels]:
+        # Semantic label found --> Exit successfully
+        sys.stdout.write("Found label " + semanticLabel + " on PR " + prId + "\n")
+        sys.exit(0)
 
 # No semantic labels attached --> Error
 sys.stderr.write("No semantic labels found on PR " + prId + "\n")

--- a/.github/scripts/genMdChangelog.py
+++ b/.github/scripts/genMdChangelog.py
@@ -35,7 +35,7 @@ with open(semanticLabelPath, 'r') as semanticLabelFile:
 # print version changelog function
 def printVersionChangelog(log: dict, version: str):
   sys.stdout.write("## Version " + version + "\n\n")
-  for label in (semanticLabels[::-1] + ["other"]):
+  for label in (semanticLabels["major"] + semanticLabels["minor"] + semanticLabels["patch"] + ["other"]):
     if label in log[version]:
       sys.stdout.write("### " + label + "\n\n")
       for change in log[version][label]:

--- a/.github/scripts/newNCVersion.py
+++ b/.github/scripts/newNCVersion.py
@@ -1,0 +1,80 @@
+#
+# @author Patrick Greyson
+#
+# Postmag - Postfix mail alias generator for Nextcloud
+# Copyright (C) 2021
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+import requests
+
+# Get arguments
+token = sys.argv[1]
+newNCVersion = sys.argv[2]
+newNCLabel = sys.argv[3]
+baseBranch = sys.argv[4]
+
+# Some configs
+ncBranchPrefix = "stable"
+prEndpoint = "https://api.github.com/repos/" + os.environ["GITHUB_REPOSITORY"] + "/pulls?state=open&base=" + baseBranch
+ncBranchesEndpoint = "https://api.github.com/repos/nextcloud/server/branches"
+headers = {
+  "Accept": "application/vnd.github.v3+json",
+  "Authorization": "Bearer " + token
+}
+
+# Search for open pull requests for nextcloud version updates
+page = 0
+prs = [None]
+while len(prs) != 0:
+  page = page+1
+  response = requests.get(prEndpoint + "&page=" + str(page), headers=headers)
+  if response.status_code != 200:
+    # No successful response --> Error
+    sys.stderr.write("Got no successful response from Github API to list PRs.\n")
+    sys.exit(1)
+
+  prs = response.json()
+  for pr in prs:
+    for label in pr["labels"]:
+      if label["name"] == newNCLabel:
+        sys.stderr.write("Open PR (#" + str(pr["number"]) + ") found with label " + newNCLabel + ". Don't open new PR.\n")
+        sys.stdout.write("False")
+        sys.exit(0)
+
+sys.stderr.write("No open PR found with label " + newNCLabel + ".\n")
+
+# Search for stable branch of new nc version
+page = 0
+branches = [None]
+while len(branches) != 0:
+  page = page+1
+  response = requests.get(ncBranchesEndpoint + "?page=" + str(page), headers=headers)
+  if response.status_code != 200:
+    # No successful response --> Error
+    sys.stderr.write("Got no successful response from Github API to list nextcloud branches.\n")
+    sys.exit(1)
+
+  branches = response.json()
+  for branch in branches:
+    if branch["name"] == ncBranchPrefix + newNCVersion:
+      sys.stderr.write("Nextcloud branch " + branch["name"] + " found. Open new PR.\n")
+      sys.stdout.write("True")
+      sys.exit(0)
+
+sys.stderr.write("No Nextcloud branch found for version " + newNCVersion + ". Don't open new PR.\n")
+sys.stdout.write("False")
+sys.exit(0)

--- a/.github/scripts/prNCVersion.py
+++ b/.github/scripts/prNCVersion.py
@@ -1,0 +1,71 @@
+#
+# @author Patrick Greyson
+#
+# Postmag - Postfix mail alias generator for Nextcloud
+# Copyright (C) 2021
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+import requests
+
+# Get arguments
+token = sys.argv[1]
+newNCVersion = sys.argv[2]
+newNCLabel = sys.argv[3]
+baseBranch = sys.argv[4]
+headBranch = sys.argv[5]
+
+# Some configs
+prEndpoint = "https://api.github.com/repos/" + os.environ["GITHUB_REPOSITORY"] + "/pulls"
+issueEndpoint = "https://api.github.com/repos/" + os.environ["GITHUB_REPOSITORY"] + "/issues"
+headers = {
+  "Accept": "application/vnd.github.v3+json",
+  "Authorization": "Bearer " + token
+}
+
+# Create PR
+prBody = """Support for new NC version.
+
+Merge the PR to support the new version.
+
+Close the PR to rebase it. A new PR with the current base will be created automatically on the next version check."""
+createBody = {
+  "title": "Support for NC version " + newNCVersion,
+  "head": headBranch,
+  "base": baseBranch,
+  "body": prBody
+}
+sys.stdout.write("Create PR...\n")
+response = requests.post(prEndpoint, headers=headers, json=createBody)
+if response.status_code != 201:
+  # PR was not created successfully
+  sys.stderr.write("Got no successful response from Github API for creating the PR.\n")
+  sys.exit(1)
+prNumber = response.json()["number"]
+
+# Add label to PR
+modifyBody = {
+  "labels": [newNCLabel]
+}
+sys.stdout.write("Add PR labels...\n")
+response = requests.patch(issueEndpoint + "/" + str(prNumber), headers=headers, json=modifyBody)
+if response.status_code != 200:
+  # PR was not modified successfully
+  sys.stderr.write("Got no successful response from Github API for adding labels to the PR.\n")
+  sys.exit(1)
+
+sys.stdout.write("Done!\n")
+sys.exit(0)

--- a/.github/scripts/updateChangelog.py
+++ b/.github/scripts/updateChangelog.py
@@ -86,9 +86,9 @@ for msg in commitMsg:
 
 # Calc new version
 major, minor, patch = version.split(".")
-if newLevel == level[0]:
+if newLevel == levels[0]:
   newVersion = major + "." + minor + "." + str(int(patch)+1)
-elif newLevel == level[1]:
+elif newLevel == levels[1]:
   newVersion = major + "." + str(int(minor)+1) + ".0"
 else:
   newVersion = str(int(major)+1) + ".0.0"

--- a/.github/workflows/new-nc-version.yml
+++ b/.github/workflows/new-nc-version.yml
@@ -66,7 +66,7 @@ jobs:
     needs: [check-status]
     if: ${{ needs.check-status.outputs.createpr == 'True' }}
     env:
-      ncversion: needs.check-status.outputs.ncversion
+      ncversion: ${{ needs.check-status.outputs.ncversion }}
     steps:
       - name: Checkout dev branch
         uses: actions/checkout@v2

--- a/.github/workflows/new-nc-version.yml
+++ b/.github/workflows/new-nc-version.yml
@@ -97,4 +97,4 @@ jobs:
           git push --set-upstream origin ${{ env.BRANCH_NAME }}
 
       - name: Create PR
-        run: python $GITHUB_WORKSPACE/.github/scripts/prNCVersion.py ${{ github.token }} ${{ env.ncversion }} ${{ env.label }} ${{ env.base }} ${{ env.BRANCH_NAME }}
+        run: python $GITHUB_WORKSPACE/.github/scripts/prNCVersion.py ${{ secrets.PAT_PUBLIC_REPOS }} ${{ env.ncversion }} ${{ env.label }} ${{ env.base }} ${{ env.BRANCH_NAME }}

--- a/.github/workflows/new-nc-version.yml
+++ b/.github/workflows/new-nc-version.yml
@@ -1,0 +1,100 @@
+#
+# @author Patrick Greyson
+#
+# Postmag - Postfix mail alias generator for Nextcloud
+# Copyright (C) 2021
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Workflow for checking for new nc versions to support
+name: new-nc-version
+
+on:
+  # Trigger the workflow every day at 5:30am
+  schedule:
+    - cron: '30 5 * * *'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+env:
+  label: "nextcloud"
+  base: "dev"
+  versions: 3
+  git_user: 'github-actions[bot]'
+  git_email: 'github-actions[bot]@users.noreply.github.com'
+
+jobs:
+  check-status:
+    runs-on: ubuntu-latest
+    outputs:
+      ncversion: ${{ steps.getncversion.outputs.ncversion }}
+      createpr: ${{ steps.status.outputs.createpr }}
+    steps:
+      - name: Checkout dev branch
+        uses: actions/checkout@v2
+        with:
+          ref: dev
+
+      - name: Get current supported NC version
+        id: getncversion
+        run: |
+          ncversion=$(( $(grep -o '<nextcloud.*min-version=\"[0-9]*\".*max-version=\"[0-9]*\"/>' $GITHUB_WORKSPACE/appinfo/info.xml | grep -o 'max-version=\"[0-9]*\"' | grep -o '[0-9]*') + 1 ))
+          echo "ncversion=$ncversion" >> $GITHUB_ENV
+          echo "::set-output name=ncversion::$ncversion"
+
+      - name: Check for open version PRs and NC version
+        id: status
+        run: echo "::set-output name=createpr::$(python $GITHUB_WORKSPACE/.github/scripts/newNCVersion.py ${{ github.token }} ${{ env.ncversion }} ${{ env.label }} ${{ env.base }})"
+
+      - name: Cleanup workspace
+        run: rm -rf $GITHUB_WORKSPACE/*
+
+  create-pr:
+    runs-on: ubuntu-latest
+    needs: [check-status]
+    if: ${{ needs.check-status.outputs.createpr == 'True' }}
+    env:
+      ncversion: needs.check-status.outputs.ncversion
+    steps:
+      - name: Checkout dev branch
+        uses: actions/checkout@v2
+        with:
+          ref: dev
+
+      - name: Config Git user and mail
+        run: |
+          cd $GITHUB_WORKSPACE
+          git config --global user.name '${{ env.git_user }}'
+          git config --global user.email '${{ env.git_email }}'
+
+      - name: Branch name
+        run: echo "BRANCH_NAME=nc${{ env.ncversion }}-$(date +%Y%m%d-%H%M)" >> $GITHUB_ENV
+
+      - name: Create branch
+        run: |
+          cd $GITHUB_WORKSPACE
+          git checkout -b ${{ env.BRANCH_NAME }}
+
+      - name: Update info.xml
+        run: sed -i "s/<nextcloud.*min-version=\"[0-9]*\".*max-version=\"[0-9]*\"\/>/<nextcloud min-version=\"$(( ${{ env.ncversion }} - ${{ env.versions }} + 1 ))\" max-version=\"$(( ${{ env.ncversion }} ))\"\/>/g" $GITHUB_WORKSPACE/appinfo/info.xml
+
+      - name: Commit new info.xml
+        run: |
+          cd $GITHUB_WORKSPACE
+          git commit -a -m "Support for NC version ${{ env.ncversion }}"
+          git push --set-upstream origin ${{ env.BRANCH_NAME }}
+
+      - name: Create PR
+        run: python $GITHUB_WORKSPACE/.github/scripts/prNCVersion.py ${{ github.token }} ${{ env.ncversion }} ${{ env.label }} ${{ env.base }} ${{ env.BRANCH_NAME }}


### PR DESCRIPTION
This PR adds a Github Action workflow that automatically opens PRs if a new Nextcloud version is available.

The only changed file in the PR is the info.xml to support the new NC version. Since app tests run on the PR Postmag is automatically tested for the new NC version.

The action will not open a new PR if there is currently an open PR for a new NC version.

Resolves #46 