### PR TITLE
Prevent parallel Github Actions workflow runs

### DIFF
--- a/.github/scripts/parallelRuns.py
+++ b/.github/scripts/parallelRuns.py
@@ -1,0 +1,61 @@
+#
+# @author Patrick Greyson
+#
+# Postmag - Postfix mail alias generator for Nextcloud
+# Copyright (C) 2021
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+import requests
+import time
+
+# Get arguments
+token = sys.argv[1]
+
+# Some configs
+workflowEndpoint = "https://api.github.com/repos/" + os.environ["GITHUB_REPOSITORY"] + "/actions/workflows/" + os.environ["GITHUB_WORKFLOW"] +".yml/runs?status=in_progress"
+headers = {
+  "Accept": "application/vnd.github.v3+json",
+  "Authorization": "Bearer " + token
+}
+
+# Sleep a little bit to wait for parallel runs to start
+sys.stderr.write("Wait 30s for other potential runs...\n")
+time.sleep(30)
+
+# Search for parallel runs
+page = 0
+workflows = [None]
+while len(workflows) != 0:
+  page = page+1
+  response = requests.get(workflowEndpoint + "&page=" + str(page), headers=headers)
+  if response.status_code != 200:
+    # No successful response --> Error
+    sys.stderr.write("Got no successful response from Github API to list workflows.\n")
+    sys.exit(1)
+
+  workflows = response.json()["workflow_runs"]
+  for workflow in workflows:
+    if str(workflow["head_sha"]) == str(os.environ["GITHUB_SHA"]):
+      # Parallel run found. Stop me if my run number is higher.
+      if int(workflow["run_number"]) < int(os.environ["GITHUB_RUN_NUMBER"]):
+        sys.stderr.write("Parallel run with smaller run number found. Stop me!\n")
+        sys.stdout.write("True")
+        sys.exit(0)
+
+sys.stderr.write("No parallel runs found (Or I'm the first run).\n")
+sys.stdout.write("False")
+sys.exit(0)

--- a/.github/scripts/parallelRuns.py
+++ b/.github/scripts/parallelRuns.py
@@ -49,7 +49,9 @@ for status in ["queued", "in_progress"]:
       sys.exit(1)
 
     workflows = response.json()["workflow_runs"]
+    sys.stderr.write(" - Me    #" + str(os.environ["GITHUB_RUN_NUMBER"]) + ": SHA " + str(os.environ["GITHUB_SHA"]) + "\n")
     for workflow in workflows:
+      sys.stderr.write(" - Other #" + str(workflow["run_number"]) + ": SHA " + str(workflow["head_sha"]) + "\n")
       if str(workflow["head_sha"]) == str(os.environ["GITHUB_SHA"]):
         # Parallel run found. Stop me if my run number is higher.
         if int(workflow["run_number"]) < int(os.environ["GITHUB_RUN_NUMBER"]):

--- a/.github/workflows/check-semantic-labels.yml
+++ b/.github/workflows/check-semantic-labels.yml
@@ -26,8 +26,27 @@ on:
     types: [ opened, reopened, synchronize, labeled, unlabeled ]
     
 jobs:
+  check-parallel-runs:
+    runs-on: ubuntu-latest
+    outputs:
+      parallelruns: ${{ steps.check.outputs.parallelruns }}
+    steps:
+      - name: Checkout dev branch
+        uses: actions/checkout@v2
+        with:
+          ref: dev
+
+      - name: Check for parallel runs
+        id: check
+        run: echo "::set-output name=parallelruns::$(python $GITHUB_WORKSPACE/.github/scripts/parallelRuns.py ${{ github.token }})"
+
+      - name: Cleanup workspace
+        run: rm -rf $GITHUB_WORKSPACE/*
+
   check-labels:
     runs-on: ubuntu-latest
+    needs: [ check-parallel-runs ]
+    if: ${{ needs.check-parallel-runs.outputs.parallelruns == 'False' }}
     steps:
       # Checks-out repository under $GITHUB_WORKSPACE
       - name: Checkout app code

--- a/.github/workflows/new-nc-version.yml
+++ b/.github/workflows/new-nc-version.yml
@@ -36,8 +36,27 @@ env:
   git_email: 'github-actions[bot]@users.noreply.github.com'
 
 jobs:
+  check-parallel-runs:
+    runs-on: ubuntu-latest
+    outputs:
+      parallelruns: ${{ steps.check.outputs.parallelruns }}
+    steps:
+      - name: Checkout dev branch
+        uses: actions/checkout@v2
+        with:
+          ref: dev
+
+      - name: Check for parallel runs
+        id: check
+        run: echo "::set-output name=parallelruns::$(python $GITHUB_WORKSPACE/.github/scripts/parallelRuns.py ${{ github.token }})"
+
+      - name: Cleanup workspace
+        run: rm -rf $GITHUB_WORKSPACE/*
+
   check-status:
     runs-on: ubuntu-latest
+    needs: [ check-parallel-runs ]
+    if: ${{ needs.check-parallel-runs.outputs.parallelruns == 'False' }}
     outputs:
       ncversion: ${{ steps.getncversion.outputs.ncversion }}
       createpr: ${{ steps.status.outputs.createpr }}
@@ -63,8 +82,8 @@ jobs:
 
   create-pr:
     runs-on: ubuntu-latest
-    needs: [check-status]
-    if: ${{ needs.check-status.outputs.createpr == 'True' }}
+    needs: [ check-parallel-runs, check-status ]
+    if: ${{ (needs.check-parallel-runs.outputs.parallelruns == 'False') && (needs.check-status.outputs.createpr == 'True') }}
     env:
       ncversion: ${{ needs.check-status.outputs.ncversion }}
     steps:

--- a/.github/workflows/package-app.yml
+++ b/.github/workflows/package-app.yml
@@ -27,8 +27,27 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-parallel-runs:
+    runs-on: ubuntu-latest
+    outputs:
+      parallelruns: ${{ steps.check.outputs.parallelruns }}
+    steps:
+      - name: Checkout dev branch
+        uses: actions/checkout@v2
+        with:
+          ref: dev
+
+      - name: Check for parallel runs
+        id: check
+        run: echo "::set-output name=parallelruns::$(python $GITHUB_WORKSPACE/.github/scripts/parallelRuns.py ${{ github.token }})"
+
+      - name: Cleanup workspace
+        run: rm -rf $GITHUB_WORKSPACE/*
+
   package-app:
     runs-on: ubuntu-latest
+    needs: [ check-parallel-runs ]
+    if: ${{ needs.check-parallel-runs.outputs.parallelruns == 'False' }}
     env:
       krankerl: 'https://github.com/ChristophWurst/krankerl/releases/download/v0.13.1/krankerl_0.13.1_amd64.deb'
     steps:

--- a/.github/workflows/release-cycle.yml
+++ b/.github/workflows/release-cycle.yml
@@ -29,8 +29,27 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-parallel-runs:
+    runs-on: ubuntu-latest
+    outputs:
+      parallelruns: ${{ steps.check.outputs.parallelruns }}
+    steps:
+      - name: Checkout dev branch
+        uses: actions/checkout@v2
+        with:
+          ref: dev
+
+      - name: Check for parallel runs
+        id: check
+        run: echo "::set-output name=parallelruns::$(python $GITHUB_WORKSPACE/.github/scripts/parallelRuns.py ${{ github.token }})"
+
+      - name: Cleanup workspace
+        run: rm -rf $GITHUB_WORKSPACE/*
+
   push-release-to-main:
     runs-on: ubuntu-latest
+    needs: [ check-parallel-runs ]
+    if: ${{ needs.check-parallel-runs.outputs.parallelruns == 'False' }}
     env:
       git_user: 'github-actions[bot]'
       git_email: 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/run-app-tests.yml
+++ b/.github/workflows/run-app-tests.yml
@@ -32,8 +32,27 @@ on:
         default: 'dev'
 
 jobs:
+  check-parallel-runs:
+    runs-on: ubuntu-latest
+    outputs:
+      parallelruns: ${{ steps.check.outputs.parallelruns }}
+    steps:
+      - name: Checkout dev branch
+        uses: actions/checkout@v2
+        with:
+          ref: dev
+
+      - name: Check for parallel runs
+        id: check
+        run: echo "::set-output name=parallelruns::$(python $GITHUB_WORKSPACE/.github/scripts/parallelRuns.py ${{ github.token }})"
+
+      - name: Cleanup workspace
+        run: rm -rf $GITHUB_WORKSPACE/*
+
   get-supported-nc-versions:
     runs-on: ubuntu-20.04
+    needs: [ check-parallel-runs ]
+    if: ${{ needs.check-parallel-runs.outputs.parallelruns == 'False' }}
     outputs:
       nc-versions: ${{ steps.output.outputs.ncversions }}
     steps:
@@ -79,7 +98,8 @@ jobs:
     
   run-tests:
     runs-on: ubuntu-20.04
-    needs: [get-supported-nc-versions]
+    needs: [ check-parallel-runs, get-supported-nc-versions ]
+    if: ${{ needs.check-parallel-runs.outputs.parallelruns == 'False' }}
     strategy:
       matrix: ${{ fromJSON(needs.get-supported-nc-versions.outputs.nc-versions) }}
     steps:


### PR DESCRIPTION
This PR adds a job to all workflows to prevent parallel runs. It seems sometimes workflow events trigger a workflow multiple times. This patch stops workflow duplicates.

Fixes #47 