### PR TITLE
default timeout for system tests

### DIFF
--- a/tests/System/journeys/adminSettings.js
+++ b/tests/System/journeys/adminSettings.js
@@ -106,9 +106,9 @@ class AdminSettings extends AbstractTest {
                 .then(() => this._driver.findElement(By.id(id)).sendKeys(data, Key.ENTER));
 
             // Wait for sending the data to backend
-            await this._driver.wait(until.elementLocated(By.className("dialogs")), 5000)
+            await this._driver.wait(until.elementLocated(By.className("dialogs")), AbstractTest.defaultWaitTimeout)
                 .then(
-                    () => this._driver.wait(until.stalenessOf(this._driver.findElement(By.className("dialogs"))), 30000)
+                    () => this._driver.wait(until.stalenessOf(this._driver.findElement(By.className("dialogs"))), 60000)
                 );
         }
         else {

--- a/tests/System/journeys/enableFilter.js
+++ b/tests/System/journeys/enableFilter.js
@@ -61,14 +61,14 @@ class EnableFilter extends AbstractTest {
     _test = async function () {
         // Disable alias 0
         await this._driver.get(this._nextcloudUrl + "/apps/postmag?id=" + this.aliases[0]["id"].toString());
-        await this._driver.wait(until.elementLocated(By.id("postmagAliasFormId")), 5000);
+        await this._driver.wait(until.elementLocated(By.id("postmagAliasFormId")), AbstractTest.defaultWaitTimeout);
         await this._driver.findElement(By.id("postmagAliasFormEnabled")).click();
         const closeIconsBeforeDisable = await this._driver.findElements(By.className("icon-close"));
         await this._driver.findElement(By.id("postmagAliasFormApply")).click();
         await this._driver.wait((driver) => async function(driver, closeIconCntBeforeDisable) {
             const closeIcons = await driver.findElements(By.className("icon-close"));
             return closeIcons.length === closeIconCntBeforeDisable+1;
-        }(driver, closeIconsBeforeDisable.length));
+        }(driver, closeIconsBeforeDisable.length), 2*AbstractTest.defaultWaitTimeout);
         this.aliases[0]["enabled"] = false;
 
         // Check elements in All-Tab
@@ -87,7 +87,7 @@ class EnableFilter extends AbstractTest {
         await this._driver.wait((driver) => async function(driver, expectedAliasCnt){
             const aliases = await driver.findElement(By.id("postmagAliasListPlaceholder")).findElements(By.tagName("a"));
             return aliases.length === expectedAliasCnt;
-        }(driver, expectedAliases.length), 5000)
+        }(driver, expectedAliases.length), AbstractTest.defaultWaitTimeout)
             .catch(() => this.assert(
                 false,
                 "Alias filter " + tabLinkId + " doesn't yield the expected number of aliases (exp: " + expectedAliases.length.toString() + ")."

--- a/tests/System/journeys/noAliases.js
+++ b/tests/System/journeys/noAliases.js
@@ -19,7 +19,7 @@
  */
 
 const {AbstractTest} = require("../testFramework");
-const {until, By} = require("selenium-webdriver");
+const {By} = require("selenium-webdriver");
 
 class NoAliases extends AbstractTest {
 

--- a/tests/System/journeys/sendTestmail.js
+++ b/tests/System/journeys/sendTestmail.js
@@ -70,7 +70,7 @@ class SendTestmail extends AbstractTest {
         // Go to maildev
         this.logger("Browse to maildev.");
         await this._driver.get(this.maildevUrl);
-        await this._driver.wait(until.elementLocated(By.className("email-list")), 5000);
+        await this._driver.wait(until.elementLocated(By.className("email-list")), AbstractTest.defaultWaitTimeout);
 
         // Check for mail to alias
         await this._driver.wait((driver) => async function(driver, alias){
@@ -83,7 +83,7 @@ class SendTestmail extends AbstractTest {
                     return true;
             }
             return false;
-        }(driver, alias), 10000)
+        }(driver, alias), 3*AbstractTest.defaultWaitTimeout)
             .catch(() => this.assert(
                 false,
                 "No test mail was sent to " + alias + "."


### PR DESCRIPTION
Adds a default timeout via a static property in AbstractTest and raises the default timeout to avoid broken tests on short selenium timeouts.

Fixes #74.