### PR TITLE
change strategy to check for staleness in system tests

### DIFF
--- a/tests/System/journeys/adminSettings.js
+++ b/tests/System/journeys/adminSettings.js
@@ -108,7 +108,7 @@ class AdminSettings extends AbstractTest {
             // Wait for sending the data to backend
             await this._driver.wait(until.elementLocated(By.className("dialogs")), AbstractTest.defaultWaitTimeout)
                 .then(
-                    () => this._driver.wait(until.stalenessOf(this._driver.findElement(By.className("dialogs"))), 60000)
+                    () => this.stableWaitForStaleness(By.className("dialogs"), 60000)
                 );
         }
         else {


### PR DESCRIPTION
This PR changes the strategy to check for the staleness of elements in system tests. Additionally it times out later when waiting for staleness. Hopefully this helps to prevent some timeouts in the app test action.

(Hopefully) fixes #83.