### PR TITLE
Change dependabot interval to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,17 +28,20 @@ updates:
     directory: "/"
     target-branch: "dev"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "thursday"
       
   - package-ecosystem: "npm"
     directory: "/"
     target-branch: "dev"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "thursday"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "dev"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "thursday"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,7 @@ updates:
   - package-ecosystem: "composer"
     directory: "/"
     target-branch: "dev"
+    rebase-strategy: "disabled"
     schedule:
       interval: "weekly"
       day: "thursday"
@@ -34,6 +35,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     target-branch: "dev"
+    rebase-strategy: "disabled"
     schedule:
       interval: "weekly"
       day: "thursday"
@@ -41,6 +43,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "dev"
+    rebase-strategy: "disabled"
     schedule:
       interval: "weekly"
       day: "thursday"


### PR DESCRIPTION
This changes the dependabot interval to weekly to prevent "spamming" of new dependency versions. Additionally it disables automatic rebasing for dependabot (I do this manually).

Keep in mind that this will take affect only after the next release cycle (when the new dependabot config is pushed to the main branch).

Fixes #101.