### PR TITLE
Make dailog box wait on admin settings system test more robust

### DIFF
--- a/tests/System/journeys/adminSettings.js
+++ b/tests/System/journeys/adminSettings.js
@@ -110,6 +110,12 @@ class AdminSettings extends AbstractTest {
             await this._driver.wait(until.elementLocated(By.className("dialogs")), AbstractTest.defaultWaitTimeout)
                 .then(
                     () => this.stableWaitForStaleness(By.className("dialogs"), AdminSettings.dialogShowTimeout)
+                        .catch(
+                            (error) => this.logger("Warning: Dialog box didn't disappear till timeout (" + error +").")
+                        )
+                )
+                .catch(
+                    (error) => this.logger("Warning: Dialog box didn't appear till timeout (" + error + ").")
                 );
         }
         else {

--- a/tests/System/journeys/adminSettings.js
+++ b/tests/System/journeys/adminSettings.js
@@ -27,6 +27,7 @@ class AdminSettings extends AbstractTest {
     static idUserAliasIdLen = "postmagUserAliasIdLen";
     static idAliasIdLen = "postmagAliasIdLen";
     static idReadyTime = "postmagReadyTime";
+    static dialogShowTimeout = 120000;
 
     origData;
 
@@ -108,7 +109,7 @@ class AdminSettings extends AbstractTest {
             // Wait for sending the data to backend
             await this._driver.wait(until.elementLocated(By.className("dialogs")), AbstractTest.defaultWaitTimeout)
                 .then(
-                    () => this.stableWaitForStaleness(By.className("dialogs"), 60000)
+                    () => this.stableWaitForStaleness(By.className("dialogs"), AdminSettings.dialogShowTimeout)
                 );
         }
         else {

--- a/tests/System/testFramework.js
+++ b/tests/System/testFramework.js
@@ -27,7 +27,7 @@ class AbstractTest {
     /**
      * @property {number} defaultWaitTimeout (static) default timeout for selenium waits
      */
-    static defaultWaitTimeout = 15000;
+    static defaultWaitTimeout = 60000;
 
     /**
      * @property {string} name (abstract) name of the test


### PR DESCRIPTION
This PR catches wait timeouts for the dialog boxes in the admin settings system tests, since we can assume that the test also sets the settings if the dialog box doesn't appear (and also if it doesn't disappear).

Hopefully this makes the test more robust.

Additionally the default timeout is increased.

Should fix #102.