### PR TITLE
add tolerance for timestamp checks in integration tests

### DIFF
--- a/tests/Integration/Controller/AliasControllerTest.php
+++ b/tests/Integration/Controller/AliasControllerTest.php
@@ -153,17 +153,17 @@ class AliasControllerTest extends TestCase {
         $this->assertSame('Fourth alias', $ret->getData()['comment'], 'Alias has not the expected comment');
         $this->assertSame(true, $ret->getData()['enabled'], 'Alias has not the expected enabled state');
         $this->assertSame(
-            $this->dateTimeFormatter->formatDateTime($now->getTimestamp(), 'short', 'medium'),
+            $this->dateTimeFormatter->formatDateTime($ret->getData()['created_utc'], 'short', 'medium'),
             $ret->getData()['created'],
-            'Alias has not the expected created timestamp'
+            'The formatted created timestamp has not the correct format'
             );
         $this->assertSame(
-            $this->dateTimeFormatter->formatDateTime($now->getTimestamp(), 'short', 'medium'),
+            $this->dateTimeFormatter->formatDateTime($ret->getData()['last_modified_utc'], 'short', 'medium'),
             $ret->getData()['last_modified'],
-            'Alias has not the expected last modified timestamp'
+            'The formatted last modified timestamp has not the correct format'
             );
-        $this->assertSame($now->getTimestamp(), $ret->getData()['created_utc'], 'Alias has not the expected created utc timestamp');
-        $this->assertSame($now->getTimestamp(), $ret->getData()['last_modified_utc'], 'Alias has not the expected last modified utc timestamp');
+        $this->assertTrue(abs($now->getTimestamp() - $ret->getData()['created_utc']) < 10, 'Alias has not the expected created utc timestamp');
+        $this->assertTrue(abs($now->getTimestamp() - $ret->getData()['last_modified_utc']) < 10, 'Alias has not the expected last modified utc timestamp');
     }
 
     public function testRead() {
@@ -216,17 +216,17 @@ class AliasControllerTest extends TestCase {
         $this->assertSame($newComment, $ret->getData()['comment'], 'Alias has not the expected comment');
         $this->assertSame($newEnabled, $ret->getData()['enabled'], 'Alias has not the expected enabled state');
         $this->assertSame(
-            $this->dateTimeFormatter->formatDateTime($this->aliases[0]->getCreated(), 'short', 'medium'),
+            $this->dateTimeFormatter->formatDateTime($ret->getData()['created_utc'], 'short', 'medium'),
             $ret->getData()['created'],
-            'Alias has not the expected created timestamp'
+            'The formatted created timestamp has not the correct format'
             );
         $this->assertSame(
-            $this->dateTimeFormatter->formatDateTime($now->getTimestamp(), 'short', 'medium'),
+            $this->dateTimeFormatter->formatDateTime($ret->getData()['last_modified_utc'], 'short', 'medium'),
             $ret->getData()['last_modified'],
-            'Alias has not the expected last modified timestamp'
+            'The formatted last modified timestamp has not the correct format'
             );
         $this->assertSame($this->aliases[0]->getCreated(), $ret->getData()['created_utc'], 'Alias has not the expected created utc timestamp');
-        $this->assertSame($now->getTimestamp(), $ret->getData()['last_modified_utc'], 'Alias has not the expected last modified utc timestamp');
+        $this->assertTrue(abs($now->getTimestamp() - $ret->getData()['last_modified_utc']) < 10, 'Alias has not the expected last modified utc timestamp');
     }
 
     public function testUpdateNotFound() {

--- a/tests/System/journeys/adminSettings.js
+++ b/tests/System/journeys/adminSettings.js
@@ -100,11 +100,12 @@ class AdminSettings extends AbstractTest {
         await this.setSingleSetting(AdminSettings.idReadyTime, data["readyTime"], true);
     }
 
-    async setSingleSetting(id, data, sendEnter = false) {
-        if(sendEnter) {
+    async setSingleSetting(id, data, waitAfterSet = false) {
+        if(waitAfterSet) {
             // Set text field
             await this._driver.findElement(By.id(id)).clear()
-                .then(() => this._driver.findElement(By.id(id)).sendKeys(data, Key.ENTER));
+                .then(() => this._driver.findElement(By.id(id)).sendKeys(data)
+                    .then(() => this._driver.findElement(By.id(id)).sendKeys(Key.ENTER)));
 
             // Wait for sending the data to backend
             await this._driver.wait(until.elementLocated(By.className("dialogs")), AbstractTest.defaultWaitTimeout)

--- a/tests/Unit/Service/AliasServiceTest.php
+++ b/tests/Unit/Service/AliasServiceTest.php
@@ -274,8 +274,8 @@ class AliasServiceTest extends TestCase {
         
         // Check timestamps
         $nowUTC = (new \DateTime("now"))->getTimestamp();
-        $this->assertTrue(($nowUTC - $ret['created_utc']) < 10, 'created utc timestamp not set correctly.');
-        $this->assertTrue(($nowUTC - $ret['last_modified_utc']) < 10, 'last modified utc timestamp not set correctly.');
+        $this->assertTrue(abs($nowUTC - $ret['created_utc']) < 10, 'created utc timestamp not set correctly.');
+        $this->assertTrue(abs($nowUTC - $ret['last_modified_utc']) < 10, 'last modified utc timestamp not set correctly.');
         
         // Check other data
         $this->assertSame($this->aliases[0]->getUserId(), $ret['user_id'], 'not the expected user id.');
@@ -352,7 +352,7 @@ class AliasServiceTest extends TestCase {
         // Check timestamps
         $nowUTC = (new \DateTime("now"))->getTimestamp();
         $this->assertSame($this->aliases[0]->getCreated(), $ret['created_utc'], 'created utc timestamp was changed.');
-        $this->assertTrue(($nowUTC - $ret['last_modified_utc']) < 10, 'last modified utc timestamp not set correctly.');
+        $this->assertTrue(abs($nowUTC - $ret['last_modified_utc']) < 10, 'last modified utc timestamp not set correctly.');
         
         // Check other data
         $this->assertSame($this->aliases[0]->getUserId(), $ret['user_id'], 'not the expected user id.');


### PR DESCRIPTION
Sometimes integration tests break due to small delays on the expected timestamps. To fix this, a small tolerance is added on the affected checks.

Fixes #107.