### PR TITLE
increase dependabot pull request limit for npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,7 @@ updates:
     directory: "/"
     target-branch: "dev"
     rebase-strategy: "disabled"
+    open-pull-requests-limit: 15
     schedule:
       interval: "weekly"
       day: "thursday"


### PR DESCRIPTION
To be sure that I don't reach the pull request limit of dependabot on the configured weekly interval for npm dependencies it is increased in this PR.

Fixes #115.