### PR TITLE
Implement navigation counters

### DIFF
--- a/src/aliasListHandler.js
+++ b/src/aliasListHandler.js
@@ -39,7 +39,8 @@ import {
 	templateContentBase,
 	templateDeleteForm,
 	templateNewAlias,
-	templateNoAliases
+	templateNoAliases,
+	setNavigationCounters
 } from "./templates";
 
 async function getAllAliases() {
@@ -66,6 +67,7 @@ $(async function() {
 	let showEnabled = true;
 	let showDisabled = true;
 
+	setNavigationCounters(aliasList);
 	if(aliasList.length === 0) {
 		templateNoAliases();
 	}
@@ -190,6 +192,7 @@ $(async function() {
 			}
 
 			aliasList = await getAllAliases();
+			setNavigationCounters(aliasList);
 			templateAliasList(aliasList, showEnabled,  showDisabled);
 			setActiveAlias(newAlias["id"]);
 			setAliasForm(newAlias, userInfo, config);
@@ -223,6 +226,7 @@ $(async function() {
 
 			// Reload alias list
 			aliasList = await getAllAliases();
+			setNavigationCounters(aliasList);
 
 			if(aliasList.length === 0) {
 				templateNoAliases();

--- a/src/templates.js
+++ b/src/templates.js
@@ -256,3 +256,16 @@ export function setActiveAlias(id) {
             $(this).removeClass("active");
     });
 }
+
+export function setNavigationCounters(aliasList) {
+    let enabledAliases = 0;
+
+    for(let i in aliasList) {
+        if (aliasList[i]['enabled'])
+            enabledAliases++;
+    }
+
+    $("#postmagAliasFilterAllCounter").text(aliasList.length.toString());
+    $("#postmagAliasFilterEnabledCounter").text(enabledAliases.toString());
+    $("#postmagAliasFilterDisabledCounter").text((aliasList.length - enabledAliases).toString());
+}

--- a/templates/index.php
+++ b/templates/index.php
@@ -34,9 +34,30 @@ Util::addScript('postmag', 'aliasListHandler');
         </div>
 
         <ul class="with-icon">
-            <li><a id="postmagAliasFilterAll" href="#" class="icon-user svg active"><?php p($l->t('All aliases')); ?></a></li>
-            <li><a id="postmagAliasFilterEnabled" href="#" class="icon-checkmark svg"><?php p($l->t('Enabled')); ?></a></li>
-            <li><a id="postmagAliasFilterDisabled" href="#" class="icon-close svg"><?php p($l->t('Disabled')); ?></a></li>
+            <li>
+                <a id="postmagAliasFilterAll" href="#" class="icon-user svg active">
+                    <?php p($l->t('All aliases')); ?>
+                    <div class="app-navigation-entry-utils">
+                        <div id="postmagAliasFilterAllCounter" class="app-navigation-entry-utils-counter">0</div>
+                    </div>
+                </a>
+            </li>
+            <li>
+                <a id="postmagAliasFilterEnabled" href="#" class="icon-checkmark svg">
+                    <?php p($l->t('Enabled')); ?>
+                    <div class="app-navigation-entry-utils">
+                        <div id="postmagAliasFilterEnabledCounter" class="app-navigation-entry-utils-counter">0</div>
+                    </div>
+                </a>
+            </li>
+            <li>
+                <a id="postmagAliasFilterDisabled" href="#" class="icon-close svg">
+                    <?php p($l->t('Disabled')); ?>
+                    <div class="app-navigation-entry-utils">
+                        <div id="postmagAliasFilterDisabledCounter" class="app-navigation-entry-utils-counter">0</div>
+                    </div>
+                </a>
+            </li>
         </ul>
 	</div>
 

--- a/templates/index.php
+++ b/templates/index.php
@@ -19,8 +19,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+use OCP\Util;
+
 style('postmag', 'style');
-script('postmag', 'aliasListHandler')
+Util::addScript('postmag', 'aliasListHandler');
 ?>
 
 <div id="app">

--- a/templates/settingsAdmin.php
+++ b/templates/settingsAdmin.php
@@ -19,8 +19,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+use OCP\Util;
+
 style('postmag', 'settingsAdmin');
-script('postmag', 'settingsAdmin');
+Util::addScript('postmag', 'settingsAdmin');
 ?>
 
 <div class="section" id="postmag">

--- a/tests/System/journeys/navigationCounters.js
+++ b/tests/System/journeys/navigationCounters.js
@@ -1,0 +1,105 @@
+/**
+ * @author Patrick Greyson
+ *
+ * Postmag - Postfix mail alias generator for Nextcloud
+ * Copyright (C) 2022
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const {AbstractTest} = require("../testFramework");
+const {until, By} = require("selenium-webdriver");
+
+class NavigationCounters extends AbstractTest {
+
+    aliases = [
+        {
+            id: -1,
+            aliasName: "hello",
+            sendTo: "hello@example.com",
+            comment: "Selenium Test 1",
+            enabled: true
+        },
+        {
+            id: -1,
+            aliasName: "world",
+            sendTo: "world@example.com",
+            comment: "Selenium Test 2",
+            enabled: true
+        },
+        {
+            id: -1,
+            aliasName: "test",
+            sendTo: "test@example.com",
+            comment: "Selenium Test 3",
+            enabled: true
+        }
+    ];
+
+    _name = "navigationCounters";
+
+    _setUp = async function() {
+        await this.goToPostmag();
+
+        for(let i = 0; i < this.aliases.length; i++) {
+            const id = await this.createAlias(this.aliases[i]);
+            this.aliases[i]["id"] = id;
+
+            this.logger("Id of created alias: " + this.aliases[i]["id"].toString());
+        }
+    }
+
+    _tearDown = async function() {
+        for(let i = 0; i < this.aliases.length; i++)
+            await this.deleteAlias(this.aliases[i]["id"]);
+    }
+
+    _test = async function () {
+        // Disable alias 0
+        await this._driver.get(this._nextcloudUrl + "/apps/postmag?id=" + this.aliases[0]["id"].toString());
+        await this._driver.wait(until.elementLocated(By.id("postmagAliasFormId")), AbstractTest.defaultWaitTimeout);
+        await this._driver.findElement(By.id("postmagAliasFormEnabled")).click();
+        const closeIconsBeforeDisable = await this._driver.findElements(By.className("icon-close"));
+        await this._driver.findElement(By.id("postmagAliasFormApply")).click();
+        await this._driver.wait((driver) => async function(driver, closeIconCntBeforeDisable) {
+            const closeIcons = await driver.findElements(By.className("icon-close"));
+            return closeIcons.length === closeIconCntBeforeDisable+1;
+        }(driver, closeIconsBeforeDisable.length), 2*AbstractTest.defaultWaitTimeout);
+        this.aliases[0]["enabled"] = false;
+
+        // Check counter in All-Tab
+        let cntAll = await this._driver.findElement(By.id("postmagAliasFilterAllCounter")).getText();
+        this.logger("All alias count: " + cntAll);
+        this.assert(
+            cntAll === this.aliases.length.toString(),
+            "The all alias counter has not the expected count " + this.aliases.length.toString() + "."
+        );
+        // Check counter in Enabled tab
+        let cntEnabled = await this._driver.findElement(By.id("postmagAliasFilterEnabledCounter")).getText();
+        this.logger("Enabled alias count: " + cntEnabled);
+        this.assert(
+            cntEnabled === (this.aliases.length - 1).toString(),
+            "The enabled alias counter has not the expected count " + this.aliases.length.toString() + "."
+        );
+        // Check counter in Disabled tab
+        let cntDisabled = await this._driver.findElement(By.id("postmagAliasFilterDisabledCounter")).getText();
+        this.logger("Disabled alias count: " + cntDisabled);
+        this.assert(
+            cntDisabled === "1",
+            "The disabled alias counter has not the expected count " + this.aliases.length.toString() + "."
+        );
+    }
+}
+
+module.exports.NavigationCounters = NavigationCounters;

--- a/tests/System/runTests.js
+++ b/tests/System/runTests.js
@@ -23,6 +23,7 @@ const {NoAliases} = require("./journeys/noAliases");
 const {CreateAliases} = require("./journeys/createAliases");
 const {ReadyTime} = require("./journeys/readyTime");
 const {EnableFilter} = require("./journeys/enableFilter");
+const {NavigationCounters} = require("./journeys/navigationCounters");
 const {SendTestmail} = require("./journeys/sendTestmail");
 
 async function runTests() {
@@ -34,6 +35,7 @@ async function runTests() {
     testFail = await new CreateAliases().run(headless) || testFail;
     testFail = await new ReadyTime().run(headless) || testFail;
     testFail = await new EnableFilter().run(headless) || testFail;
+    testFail = await new NavigationCounters().run(headless) || testFail;
     testFail = await new SendTestmail().run(headless) || testFail;
 
     if (testFail)


### PR DESCRIPTION
This PR implements counters in the app navigation to show the user how many aliases were created, and how many of them are enabled and disabled.

Implements #131.