### PR TITLE
Fix indentation for setup-node of package-app.yml

### DIFF
--- a/.github/workflows/package-app.yml
+++ b/.github/workflows/package-app.yml
@@ -58,9 +58,9 @@ jobs:
           ref: main
 
       - name: Set node version
-          uses: actions/setup-node@v3.5.1
-          with:
-            node-version: '16'
+        uses: actions/setup-node@v3.5.1
+        with:
+          node-version: '16'
 
       - name: Download and install krankerl
         run: |


### PR DESCRIPTION
This fixes the workflow package-app because of wrong indentation on setup-node.
Fixes #274