### PR TITLE
Support for NC version 26

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@
     <repository type="git">https://github.com/patrick1990/postmag-nc.git</repository>
     <screenshot>https://raw.githubusercontent.com/patrick1990/postmag-nc/main/screenshots/postmag.png</screenshot>
     <dependencies>
-        <nextcloud min-version="23" max-version="25"/>
+        <nextcloud min-version="24" max-version="26"/>
     </dependencies>
     <commands>
 		<command>OCA\Postmag\Command\Aliases</command>


### PR DESCRIPTION
Support for new NC version.

Merge the PR to support the new version.

Close the PR to rebase it. A new PR with the current base will be created automatically on the next version check.