### PR TITLE
Support for NC version 28

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@
     <repository type="git">https://github.com/patrick1990/postmag-nc.git</repository>
     <screenshot>https://raw.githubusercontent.com/patrick1990/postmag-nc/main/screenshots/postmag.png</screenshot>
     <dependencies>
-        <nextcloud min-version="25" max-version="27"/>
+        <nextcloud min-version="26" max-version="28"/>
     </dependencies>
     <commands>
 		<command>OCA\Postmag\Command\Aliases</command>


### PR DESCRIPTION
Support for new NC version.

Merge the PR to support the new version.

Close the PR to rebase it. A new PR with the current base will be created automatically on the next version check.